### PR TITLE
Fix MOLE mode positioning and hole occupancy

### DIFF
--- a/game.js
+++ b/game.js
@@ -192,6 +192,7 @@ function buildMoleBoard (opts = cfg) {
     hole.style.pointerEvents = 'none';
     cell.appendChild(hole);
     gameContainer.appendChild(cell);
+    cell.dataset.busy = '';
     moleHoles.push(cell);
   }
 }
@@ -514,15 +515,19 @@ registerMode(MODES.BALLOONS, new BalloonGame(modeCfgs[MODES.BALLOONS]));
 class MoleGame extends GameMode {
   spawn() {
     if (state.sprites.length >= this.opts.moleCount) return;
-    const hole = pick(moleHoles);
+    const freeHoles = moleHoles.filter(h => !h.dataset.busy);
+    if (freeHoles.length === 0) return;
+    const hole = pick(freeHoles);
+    hole.dataset.busy = '1';
     const rect = hole.getBoundingClientRect();
     const r = Math.min(rect.width, rect.height) * 0.40;
-    const x = rect.width * 0.5;
+    const x = hole.clientWidth * 0.5;
     const y = rect.height + r;
     const dx = 0;
     const dy = -this.opts.moleUpV;
     const e = pick(this.opts.animals);
     const s = new Sprite({ x, y, dx, dy, r, e, face:1, dir:1 });
+    s.hole = hole;
     s.phase = 'up';
     s.timer = between(this.opts.moleStayMin, this.opts.moleStayMax) / 1000;
     s.el.remove();
@@ -663,7 +668,11 @@ function maintain() {
   // remove dead sprites
   for (let i = state.sprites.length - 1; i >= 0; i--) {
     if (!state.sprites[i].alive) {
-      state.sprites[i].el.remove();
+      const sp = state.sprites[i];
+      if (sp.mode === ModeHandlers[MODES.MOLE] && sp.hole) {
+        sp.hole.dataset.busy = '';
+      }
+      sp.el.remove();
       state.sprites.splice(i, 1);
     }
   }


### PR DESCRIPTION
## Summary
- center moles horizontally within their hole container
- prevent multiple moles from occupying the same hole
- clear hole occupancy when sprites are removed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b008a0f20832c9c37ad23aeae00f5