### PR TITLE
Fix mole centering

### DIFF
--- a/game.js
+++ b/game.js
@@ -190,6 +190,9 @@ function buildMoleBoard (opts = cfg) {
     hole.style.fontSize = '30vh';
     hole.style.lineHeight = '27vh';
     hole.style.pointerEvents = 'none';
+    hole.style.textAlign = 'center';
+    hole.style.display = 'block';
+    hole.style.width = '100%';
     cell.appendChild(hole);
     gameContainer.appendChild(cell);
     cell.dataset.busy = '';


### PR DESCRIPTION
## Summary
- center the hole emoji by making it block level and width 100%

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_684b18fb69cc832c99079e11c2e9c641