### PR TITLE
Offload particle animation to CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -172,6 +172,12 @@ input[type="range"] {
   pointer-events: none;
   user-select: none;
   transform-origin: center;
+  animation: particleMove var(--life, 1s) linear forwards;
+}
+
+@keyframes particleMove {
+  from { transform: translate3d(0, 0, 0); opacity: 1; }
+  to   { transform: translate3d(var(--dx), var(--dy), 0); opacity: 0; }
 }
 
 .moleHole {


### PR DESCRIPTION
## Summary
- move particle lifecycle management from JS to CSS
- create `particleMove` keyframes
- clean up unused particle state

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684c56f030f8832c99af29563f364c82