### PR TITLE
Use SVG background for mole holes

### DIFF
--- a/game.js
+++ b/game.js
@@ -171,10 +171,6 @@ function buildMoleBoard (opts = cfg) {
   for (let i = 0; i < total; ++i) {
     const cell = document.createElement('div');
     cell.className = 'moleHole';
-    const hole = document.createElement('div');
-    hole.className = 'moleHoleIcon';
-    hole.textContent = '🕳️';
-    cell.appendChild(hole);
     gameContainer.appendChild(cell);
     cell.dataset.busy = '';
     moleHoles.push(cell);

--- a/style.css
+++ b/style.css
@@ -185,13 +185,10 @@ input[type="range"] {
   display: flex;
   align-items: flex-end;
   pointer-events: none;
-}
-
-.moleHoleIcon {
-  font-size: 30vh;
-  line-height: 27vh;
-  pointer-events: none;
-  text-align: center;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 30'%3E%3Cellipse cx='50' cy='15' rx='50' ry='15' fill='black'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: bottom;
+  background-size: contain;
 }
 
 .burst {


### PR DESCRIPTION
## Summary
- simplify mole board builder by dropping the emoji child element
- style mole holes with an SVG ellipse background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c635f5a48832caac46c9d479923d4