### PR TITLE
Encapsulate setup controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -638,6 +638,11 @@ function updateScore() {
   bs.textContent = `${state.scores.teamB}`;
 }
 
+function setTeams(a, b) {
+  as.className = a;
+  bs.className = b;
+}
+
 function calculatePoints(sprite) {
   // Smaller & faster ⇒ larger score; Bigger & slower ⇒ smaller score
   const speed = Math.hypot(sprite.dx, sprite.dy);
@@ -730,6 +735,7 @@ const Game = {
   cfg,
   state,
   utils: { rand, between, applyTransform },
+  setTeams,
   setMode,
   spawn,
   burst


### PR DESCRIPTION
## Summary
- wrap ROI and control logic inside new `Setup` IIFE
- save config changes and update scoreboard with `Game.setTeams`
- compute top ROI from saved polygon for detection
- expose Setup.bind during startup

## Testing
- `node --check app.js`
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684cf6e7e19c832ca3bf90d577f933f0