### PR TITLE
Fix transforms, remove cfg duplication

### DIFF
--- a/game.js
+++ b/game.js
@@ -225,27 +225,9 @@ const randVec = (speed = randSpeed()) => {
 
 
 function applyTransform(el, x, y, rot, sx, sy) {
-  // cache typed OM objects on the element so we don't recreate
-  // them on every frame. When called the first time we create the
-  // CSSTransformValue and reuse the individual components thereafter.
-  let cache = el._tf;
-  if (!cache) {
-    const pxX = CSS.px(x);
-    const pxY = CSS.px(y);
-    const ang = CSS.rad(rot);
-    const translate = new CSSTranslate(pxX, pxY);
-    const rotate = new CSSRotate(ang);
-    const scale = new CSSScale(sx, sy);
-    const tv = new CSSTransformValue([translate, rotate, scale]);
-    el.attributeStyleMap.set('transform', tv);
-    cache = el._tf = { translate, rotate, scale, pxX, pxY, ang };
-  } else {
-    cache.pxX.value = x;
-    cache.pxY.value = y;
-    cache.ang.value = rot;
-    cache.scale.x = sx;
-    cache.scale.y = sy;
-  }
+  const st = el._st || (el._st = el.style);
+  st.transform =
+    `translate3d(${x}px, ${y}px, 0) rotate(${rot}rad) scale(${sx}, ${sy})`;
 }
 
 // PARTICLE CLASS (DOM version)

--- a/screen.js
+++ b/screen.js
@@ -21,8 +21,8 @@ obs1.observe(sec1);
 
 // Section 2
 const sec2 = document.getElementById('configScreen');
-const cfg = App.Config.get();
-Game.setTeams(cfg.teamA, cfg.teamB);
+const cfgGame = App.Config.get();
+Game.setTeams(cfgGame.teamA, cfgGame.teamB);
 const obs2 = createSectionObserver(
     () => { console.log('Enter configScreen'); App.Controller.setPreview(true); },
     () => { console.log('Leave configScreen'); App.Controller.setPreview(false); }


### PR DESCRIPTION
## Summary
- remove CSS Typed OM code and use standard `style.transform`
- avoid global cfg variable clash by renaming cfg in screen.js
- cache style in `applyTransform` and use `translate3d`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d652d2da8832cba83665afbef0862