### PR TITLE
Start random game mode on load

### DIFF
--- a/game.js
+++ b/game.js
@@ -656,3 +656,10 @@
 
   Game.registerMode(Game.MODES.MOLE, new MoleGame(cfg));
 })(Game);
+
+// Start a random game mode on page load
+(function(Game){
+  const modes = Object.values(Game.MODES);
+  const randomMode = modes[Math.floor(Math.random() * modes.length)];
+  Game.setMode(randomMode);
+})(Game);


### PR DESCRIPTION
## Summary
- add small script to pick a random game mode at page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68769d15b638832c85834ef994a208aa