### PR TITLE
Animate mole rise using height

### DIFF
--- a/game.js
+++ b/game.js
@@ -575,10 +575,11 @@
 
         const s = new Game.Sprite({ x, y: ground - r, dx: 0, dy: 0, r, e: Game.utils.pick(cfg.animals), face: 1, dir: 1 });
         s.el.classList.add('mole');
+        s.el.style.setProperty('--mole-h', `${r * 2}px`);
         Object.assign(s.el.style, {
           left: `${x - r}px`,
           top: `${ground - r * 2}px`,
-          transform: 'scaleY(0)'
+          height: '0px'
         });
         s.phase = 'up';
         s.row = row;

--- a/style.css
+++ b/style.css
@@ -164,7 +164,7 @@ input[type="range"] {
   overflow: hidden;
   align-items: flex-end;
   transform-origin: bottom;
-  will-change: transform;
+  will-change: height;
 }
 
 .particle {
@@ -187,13 +187,13 @@ input[type="range"] {
 
 
 @keyframes moleRise {
-  from { transform: scaleY(0); }
-  to   { transform: scaleY(1); }
+  from { height: 0; }
+  to   { height: var(--mole-h); }
 }
 
 @keyframes moleFall {
-  from { transform: scaleY(1); }
-  to   { transform: scaleY(0); }
+  from { height: var(--mole-h); }
+  to   { height: 0; }
 }
 
 .burst {


### PR DESCRIPTION
## Summary
- update mole emoji animation to grow by height instead of transform
- adjust CSS keyframes and styles for new height-based animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876ac71c4e4832cb16b3350df8693fc