### PR TITLE
Synchronize sprite count property

### DIFF
--- a/games/emoji.js
+++ b/games/emoji.js
@@ -8,7 +8,7 @@
     '🧋','🌞','🌺','🌵','📸','⌚','🧸'
   ];
 
-  const MAX_EMOJIS = 6;
+  const EMOJI_COUNT = 6;
   const R_MIN = 25;
   const R_MAX = 90;
   const V_MIN = 10;
@@ -19,7 +19,7 @@
 
   g.GameRegister('emoji', g.BaseGame.make({
     theme      : 'sky',
-    max        : MAX_EMOJIS,
+    count      : EMOJI_COUNT,
     emojis     : EMOJI_SET,
     spawnEvery : SPAWN_SECS,
 


### PR DESCRIPTION
## Summary
- rename `max` to `count` in emoji game configuration
- keep constant for emoji count but use unified property name

## Testing
- `grep -n EMOJI_COUNT -r .`

------
https://chatgpt.com/codex/tasks/task_e_687a7bac03c4832caabaa8ca179ff962