### PR TITLE
Refactor fish mode for lightweight engine

### DIFF
--- a/games/fish.js
+++ b/games/fish.js
@@ -1,51 +1,44 @@
 (function(g){
   const FISH_SET = ['🐳','🐋','🐬','🦭','🐟','🐠','🦈','🐙','🪼','🦀','🦞','🦐'];
-  const BUBBLE_SET = ['🫧'];
   const FISH_MAX = 6;
   const SPAWN_SECS = 0.6;
+  const R_MIN = 25;
+  const R_MAX = 90;
+  const V_MIN = 10;
+  const V_MAX = 180;
 
   g.GameRegister('fish', g.BaseGame.make({
     theme: 'ocean',
-    count: FISH_MAX,
+    max: FISH_MAX,
     emojis: FISH_SET,
     spawnEvery: SPAWN_SECS,
     bounceX: false,
     bounceY: true,
 
     spawn(){
-      const r = g.R.between(this.cfg.rMin, this.cfg.rMax);
+      const r = g.R.between(R_MIN, R_MAX);
       const fromLeft = Math.random() < 0.5;
-      const face = fromLeft ? 1 : -1;
       const x = fromLeft ? -r : this.W + r;
       const y = g.R.between(r, this.H - r);
-      const dx = face * g.R.between(this.cfg.vMin, this.cfg.vMax);
+      const dx = (fromLeft ? 1 : -1) * g.R.between(V_MIN, V_MAX);
       const dy = g.R.between(-20, 20);
-      const dir = -face;
-      const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), face, dir, angle: 0, pop:0 });
-      sp.draw = function(){
-        g.applyTransform(sp.el, sp.x - sp.r, sp.y - sp.r, sp.angle || 0, sp.face>0?-1:1, 1);
-      };
+      const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), hp:1 });
+      if (dx < 0) sp.el.style.scale = '-1 1';
+      return null;
     },
 
     move(s, dt){
       s.x += s.dx * dt;
       s.y += s.dy * dt;
-      if(s.pop > 0){
-        s.pop += dt;
-        s.angle += dt * this.cfg.spin * s.dir;
-        s.dx *= 1.25;
-      } else {
-        if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;
-      }
+      if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;
       if(
         s.x < -s.r*2 || s.x > this.W + s.r*2 ||
         s.y < -s.r*2 || s.y > this.H + s.r*2
-      ) s.alive = false;
+      ) s.remove();
+      s.draw();
     },
 
-    onHit(s){
-      s.el.classList.add('spin');
-      this.burst(s.x, s.y, BUBBLE_SET);
+    onHit(_s){
     }
   }));
 })(window);


### PR DESCRIPTION
## Summary
- update fish mode constants and ranges
- simplify spawn using addSprite and CSS mirroring
- remove unused spin/pop logic
- keep only minimal move and onHit hooks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687be32f9268832ca4e04f75c6fc6316