### PR TITLE
Remove theme option and cleanup game configs

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -32,7 +32,9 @@ const baseCfg = {
   winPoints  : 30,                  // first team to reach this wins
   spawnEvery : 0.6,                 // seconds between spawns
   emojis     : ['😀','😎','🤖','👻'], // fallback artwork
-  collisions : false               // enable physics collisions
+  collisions : false,              // enable physics collisions
+  bounceX    : false,
+  bounceY    : false
 };
 
 /* ══════════ 2.  Sprite  – one emoji on screen ══════════ */
@@ -122,7 +124,7 @@ class BaseGame {
     };
     this.container.addEventListener('pointerdown', this.onPointerDown);
     this.container.addEventListener('contextmenu', e => e.preventDefault());
-    this.container.className = 'game' + (this.cfg.theme ? ' ' + this.cfg.theme : '');
+    this.container.className = 'game' + (this.gameName ? ' ' + this.gameName : '');
   }
 
   /* ---- 3.3 main loop : called from rAF ---- */
@@ -172,8 +174,12 @@ class BaseGame {
   /* ---- 3.6 COLLISION helpers ---- */
   _wallBounce(s) {
     const W = this.W, H = this.H;
-    if ((s.x - s.r < 0 && s.dx < 0) || (s.x + s.r > W && s.dx > 0)) s.dx *= -1;
-    if ((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > H && s.dy > 0)) s.dy *= -1;
+    if (this.cfg.bounceX && ((s.x - s.r < 0 && s.dx < 0) || (s.x + s.r > W && s.dx > 0))) {
+      s.dx *= -1;
+    }
+    if (this.cfg.bounceY && ((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > H && s.dy > 0))) {
+      s.dy *= -1;
+    }
   }
   static _moveDefault(s, dt) {
     s.x += s.dx * dt;
@@ -286,7 +292,10 @@ const REG = [];
 let idx = -1;
 let inst = null;
 
-Game.register = (id, cls) => REG.push({ id, cls });
+Game.register = (id, cls) => {
+  cls.prototype.gameName = id;
+  REG.push({ id, cls });
+};
 
 Object.defineProperty(Game, 'current', { get: () => idx });
 Object.defineProperty(Game, 'list',    { get: () => REG.map(e => e.id) });

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -15,12 +15,9 @@
   const SAT_MAX      = 1.0;
 
   g.Game.register('balloon', g.BaseGame.make({
-    theme: 'balloon',
     max: BALLOON_MAX,
     emojis: BALLOON_SET,
     spawnEvery: SPAWN_SECS,
-    bounceX: false,
-    bounceY: false,
 
     spawn(){
       const r = g.R.between(R_MIN, R_MAX);

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -18,7 +18,6 @@
   const WOBBLE_FREQ = 0.03;
 
   g.Game.register('emoji', g.BaseGame.make({
-    theme      : 'sky',
     count      : EMOJI_COUNT,
     emojis     : EMOJI_SET,
     spawnEvery : SPAWN_SECS,

--- a/games/fish.js
+++ b/games/fish.js
@@ -8,11 +8,9 @@
   const V_MAX = 180;
 
   g.Game.register('fish', g.BaseGame.make({
-    theme: 'ocean',
     max: FISH_MAX,
     emojis: FISH_SET,
     spawnEvery: SPAWN_SECS,
-    bounceX: false,
     bounceY: true,
 
     spawn(){

--- a/games/mole.js
+++ b/games/mole.js
@@ -39,12 +39,9 @@
   }
 
   g.Game.register('mole', g.BaseGame.make({
-    theme: 'mole',
     count: MOLE_COUNT,
     emojis: MOLE_EMOJIS,
     spawnEvery: SPAWN_SECS,
-    bounceX: false,
-    bounceY: false,
 
     onStart(){
       buildGrid(this);


### PR DESCRIPTION
## Summary
- drop theme setting from game-engine
- assign game id as container class
- default bounceX/bounceY to `false`
- clean up game config files

## Testing
- `node --check game-engine.js`
- `node --check games/balloon.js`
- `node --check games/fish.js`
- `node --check games/mole.js`
- `node --check games/emoji.js`


------
https://chatgpt.com/codex/tasks/task_e_687c0255af60832cba0634173e10bd25