### PR TITLE
Implement spawn and pop CSS classes

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -50,6 +50,7 @@ class Sprite {
 
     this.el = document.createElement('div');
     this.el.className = 'emoji';
+    this.el.classList.add('spawn');
     this.el.textContent = e;
     const size = this.r * 2;
     Object.assign(this.el.style, {
@@ -242,6 +243,7 @@ class BaseGame {
 
   /* ---- 3.8 POP animation ---- */
   _popSprite(s) {                // visual + remove()
+    s.el.classList.remove('spawn');
     s.el.classList.add('pop');
     this.burst(s.x, s.y);
     setTimeout(() => s.remove(), 200);

--- a/games/mole.js
+++ b/games/mole.js
@@ -63,7 +63,6 @@
       const sp = this.addSprite({ x: hole.x, y: hole.y, dx:0, dy:0, r:this.holeR, e: g.R.pick(this.emojis), hp:1 });
       sp.el.classList.add('mole');
       sp.el.style.setProperty('--mole-h', `${this.holeR*2}px`);
-      sp.el.style.animation = 'moleRise 0.3s forwards';
       sp.holeIndex = idx;
       sp.ttl = g.R.between(MOLE_STAY_MIN, MOLE_STAY_MAX) / 1000;
     },
@@ -83,7 +82,6 @@
     onHit(sp){
       const hole = this.holes[sp.holeIndex];
       if(hole) hole.occupied = false;
-      sp.el.style.animation = 'moleFall 0.3s forwards';
     }
 
   }));

--- a/style.css
+++ b/style.css
@@ -304,3 +304,40 @@ input[type="range"] {
       0 0 0 16vh rgba(0, 162, 255, 0);
   }
 }
+
+/* ----- Spawn and Pop effects ----- */
+.game.emoji .spawn { animation: emojiSpawn 0.3s ease-out forwards; }
+.game.emoji .pop   { animation: emojiPop 0.2s ease-out forwards; }
+
+@keyframes emojiSpawn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+@keyframes emojiPop {
+  to { transform: scale(0); opacity: 0; }
+}
+
+.game.balloon .spawn { animation: balloonSpawn 0.3s ease-out forwards; }
+.game.balloon .pop   { animation: balloonPop 0.2s ease-out forwards; }
+
+@keyframes balloonSpawn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+@keyframes balloonPop {
+  to { transform: translateY(-20px) scale(0); opacity: 0; }
+}
+
+.game.fish .spawn { animation: fishSpawn 0.3s ease-out forwards; }
+.game.fish .pop   { animation: fishPop 0.2s ease-out forwards; }
+
+@keyframes fishSpawn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+@keyframes fishPop {
+  to { transform: scale(0); opacity: 0; }
+}
+
+.game.mole .spawn { animation: moleRise 0.3s forwards; }
+.game.mole .pop   { animation: moleFall 0.3s forwards; }


### PR DESCRIPTION
## Summary
- add `spawn` class in Sprite creation and remove it when popping
- move mole animation triggers to CSS by removing JS animation calls
- define spawn/pop animations for each game in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c0823aef8832c9f3c4f4e694372f0