### PR TITLE
Move mole TTL handling to engine

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -147,10 +147,15 @@ class BaseGame {
 
     if (this.cfg.collisions) this._resolveCollisions();
 
-    for (const s of this.sprites) s.draw();
+    for (const s of this.sprites) {
+      if (s.ttl !== undefined && (s.ttl -= dt) <= 0) {
+        this._popSprite(s);
+        continue;            // skip draw for a popped sprite
+      }
+      s.draw();
+    }
 
     this.sprites = this.sprites.filter(sp => sp.alive);
-    if (this.tick) this.tick(dt);
   }
 
   /* ---- 3.4 factory : create + register a sprite ---- */
@@ -166,6 +171,7 @@ class BaseGame {
     };
     const full = { hp: 1, ...otherDefaults, ...desc };
     const sprite = new Sprite(full);
+    if (desc.ttl !== undefined) sprite.ttl = desc.ttl;
     this.sprites.push(sprite);
     return sprite;
   }

--- a/games/mole.js
+++ b/games/mole.js
@@ -2,6 +2,7 @@
   const MOLE_UP_V = 350;
   const MOLE_STAY_MIN = 1000;
   const MOLE_STAY_MAX = 3000;
+  const MOLE_LIFETIME_SECS = 2;
   const MOLE_COUNT = 12;
   const MOLE_EMOJIS = ['🐭','🐰'];
   const MOLE_ROWS = [3,2,3];
@@ -57,24 +58,21 @@
       if(idx === -1) return null;
       const hole = this.holes[idx];
       hole.occupied = true;
-      const sp = this.addSprite({ x: hole.x, y: hole.y, dx:0, dy:0, r:this.holeR, e: g.R.pick(this.emojis), hp:1 });
+      const sp = this.addSprite({
+        x: hole.x,
+        y: hole.y,
+        dx: 0,
+        dy: 0,
+        r: this.holeR,
+        e: g.R.pick(this.emojis),
+        hp: 1,
+        ttl: MOLE_LIFETIME_SECS
+      });
       sp.el.classList.add('mole');
       sp.el.style.setProperty('--mole-h', `${this.holeR*2}px`);
       sp.holeIndex = idx;
-      sp.ttl = g.R.between(MOLE_STAY_MIN, MOLE_STAY_MAX) / 1000;
     },
 
-    tick(dt){
-      for(const sp of this.sprites){
-        if(sp.ttl == null) continue;
-        sp.ttl -= dt;
-        if(sp.ttl <= 0){
-          const hole = this.holes[sp.holeIndex];
-          if(hole) hole.occupied = false;
-          this._popSprite(sp);
-        }
-      }
-    },
 
     onHit(sp){
       const hole = this.holes[sp.holeIndex];


### PR DESCRIPTION
## Summary
- move sprite expiration to BaseGame loop
- support ttl property in `addSprite`
- use ttl in mole spawn and drop per-frame tick

## Testing
- `grep -n "tick" -n games/mole.js`

------
https://chatgpt.com/codex/tasks/task_e_687c9eaf8bd0832c96f347ba932fdbfc