### PR TITLE
Adjust game configuration and movement

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -12,17 +12,12 @@ const R = {
 };
 win.R = R;
 
-function applyTransform(el, x, y, rot, sx, sy) {
-  const st = el._st || (el._st = el.style);
-  st.transform =
-    `translate3d(${x}px, ${y}px, 0) rotate(${rot}rad) scale(${sx}, ${sy})`;
-}
 
 const DEFAULT_BURST = ['✨', '💥', '💫'];
 
 const baseCfg = {
   mode: 'emoji',
-  count: 6,
+  max: 6,
   rMin: 25,
   rMax: 90,
   vMin: 10,
@@ -132,7 +127,7 @@ class BaseGame {
 
   /* ---- 3.3 main loop : called from rAF ---- */
   loop(dt) {
-    if (this.sprites.length < this.cfg.count) {
+    if (this.sprites.length < this.cfg.max) {
       this.spawnClock -= dt;
       if (this.spawnClock <= 0) {
         this.spawnClock = this.cfg.spawnEvery;

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -43,7 +43,6 @@
         s.x < -s.r*2 || s.x > this.W + s.r*2 ||
         s.y < -s.r*2 || s.y > this.H + s.r*2
       ) s.remove();
-      s.draw();
     }
   }));
 })(window);

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -22,6 +22,8 @@
     emojis     : EMOJI_SET,
     spawnEvery : SPAWN_SECS,
     collisions : true,
+    bounceX    : true,
+    bounceY    : true,
 
     spawn() {
       const r = g.R.between(R_MIN, R_MAX);
@@ -49,7 +51,6 @@
       s.y += Math.sin(s.wob) * WOBBLE_AMPL;
       s.x += s.dx * dt;
       s.y += s.dy * dt;
-      this._wallBounce(s);
     }
   }));
 })(window);

--- a/games/fish.js
+++ b/games/fish.js
@@ -34,7 +34,6 @@
         s.x < -s.r*2 || s.x > this.W + s.r*2 ||
         s.y < -s.r*2 || s.y > this.H + s.r*2
       ) s.remove();
-      s.draw();
     },
 
     onHit(_s){

--- a/games/mole.js
+++ b/games/mole.js
@@ -49,9 +49,6 @@
       buildGrid(this);
     },
 
-    end(winner){
-      g.BaseGame.prototype.end.call(this, winner);
-    },
 
     spawn(){
       const idx = this.holes.findIndex(h => !h.occupied);


### PR DESCRIPTION
## Summary
- remove unused `applyTransform` helper
- rename `count` to `max` in the base config and loop
- let emoji game sprites bounce off walls
- stop drawing removed sprites in balloon and fish games
- drop custom `end` override from mole game

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cbb320010832ca7856aa2943d8808