### PR TITLE
Universal offscreen cleanup in engine

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -42,6 +42,7 @@ class Sprite {
     this.r = r; this.e = e;
     this.mass = r * r;
     this.alive = true;
+    this.entered = false;
 
     this.el = document.createElement('div');
     this.el.className = 'emoji';
@@ -138,6 +139,18 @@ class BaseGame {
     for (const s of this.sprites) {
       this.move ? this.move(s, dt) : BaseGame._moveDefault(s, dt);
       this._wallBounce(s);
+
+      const left   = s.x - s.r;
+      const right  = s.x + s.r;
+      const top    = s.y - s.r;
+      const bottom = s.y + s.r;
+      if (!s.entered) {
+        if (right >= 0 && left <= this.W && bottom >= 0 && top <= this.H) {
+          s.entered = true;
+        }
+      } else if (right < 0 || left > this.W || bottom < 0 || top > this.H) {
+        s.remove();
+      }
     }
 
     if (this.cfg.collisions) this._resolveCollisions();

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -39,10 +39,6 @@
       s.sway = (s.sway || 0) + dt * WOBBLE_FREQ;
       s.x += s.dx * dt + Math.sin(s.sway) * WOBBLE_AMPL;
       s.y += s.dy * dt;
-      if(
-        s.x < -s.r*2 || s.x > this.W + s.r*2 ||
-        s.y < -s.r*2 || s.y > this.H + s.r*2
-      ) s.remove();
     }
   }));
 })(window);

--- a/games/fish.js
+++ b/games/fish.js
@@ -30,10 +30,6 @@
       s.x += s.dx * dt;
       s.y += s.dy * dt;
       if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;
-      if(
-        s.x < -s.r*2 || s.x > this.W + s.r*2 ||
-        s.y < -s.r*2 || s.y > this.H + s.r*2
-      ) s.remove();
     },
 
     onHit(_s){


### PR DESCRIPTION
## Summary
- add an `entered` flag to sprites
- remove offscreen checks from balloon and fish modes
- handle offscreen removal for every sprite in `BaseGame.loop`

## Testing
- `node --check game-engine.js`
- `node --check games/balloon.js`
- `node --check games/fish.js`

------
https://chatgpt.com/codex/tasks/task_e_687ce5c70814832c8dbb461ea028cc1e