### PR TITLE
Enable random spawn delay per game

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -29,8 +29,9 @@ const baseCfg = {
   burstN: 14,
   particleLife: 1,
   burst: DEFAULT_BURST,
-  winPoints  : 30,                  // first team to reach this wins
-  spawnEvery : 0.6,                 // seconds between spawns
+  winPoints     : 30,                  // first team to reach this wins
+  spawnDelayMin : 0,                   // seconds (min)
+  spawnDelayMax : 3,                   // seconds (max)
   emojis     : ['😀','😎','🤖','👻'], // fallback artwork
   collisions : false,              // enable physics collisions
   bounceX    : false,
@@ -85,7 +86,8 @@ class BaseGame {
     this.sprites = [];
     this.score = [0, 0];
     this.running = true;
-    this.spawnClock = 0;
+    this._spawnElapsed = 0;
+    this._nextSpawn = R.between(this.cfg.spawnDelayMin, this.cfg.spawnDelayMax);
   }
 
   /* ---- 3.2 init : call ONCE after construction ---- */
@@ -132,9 +134,10 @@ class BaseGame {
   /* ---- 3.3 main loop : called from rAF ---- */
   loop(dt) {
     if (this.sprites.length < this.cfg.max) {
-      this.spawnClock -= dt;
-      if (this.spawnClock <= 0) {
-        this.spawnClock = this.cfg.spawnEvery;
+      this._spawnElapsed += dt;
+      if (this._spawnElapsed >= this._nextSpawn) {
+        this._spawnElapsed = 0;
+        this._nextSpawn = R.between(this.cfg.spawnDelayMin, this.cfg.spawnDelayMax);
         const desc = this.spawn();
         if (desc) this.addSprite(desc);
       }

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -8,7 +8,8 @@
   const B_V_MAX      = 60;
   const WOBBLE_FREQ  = 0.03;
   const WOBBLE_AMPL  = 0.10;
-  const SPAWN_SECS   = 0.6;
+  const SPAWN_DELAY_MIN = 0;
+  const SPAWN_DELAY_MAX = 3;
   const BRIGHT_MIN   = 0.9;
   const BRIGHT_MAX   = 2;
   const SAT_MIN      = 0.9;
@@ -17,7 +18,8 @@
   g.Game.register('balloon', g.BaseGame.make({
     max: BALLOON_MAX,
     emojis: BALLOON_SET,
-    spawnEvery: SPAWN_SECS,
+    spawnDelayMin: SPAWN_DELAY_MIN,
+    spawnDelayMax: SPAWN_DELAY_MAX,
 
     spawn(){
       const r = g.R.between(R_MIN, R_MAX);

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -13,14 +13,16 @@
   const R_MAX = 90;
   const V_MIN = 10;
   const V_MAX = 180;
-  const SPAWN_SECS = 0.6;
+  const SPAWN_DELAY_MIN = 0;
+  const SPAWN_DELAY_MAX = 3;
   const WOBBLE_AMPL = 0.10;
   const WOBBLE_FREQ = 0.03;
 
   g.Game.register('emoji', g.BaseGame.make({
     max        : EMOJI_COUNT,
     emojis     : EMOJI_SET,
-    spawnEvery : SPAWN_SECS,
+    spawnDelayMin : SPAWN_DELAY_MIN,
+    spawnDelayMax : SPAWN_DELAY_MAX,
     collisions : true,
     bounceX    : true,
     bounceY    : true,

--- a/games/fish.js
+++ b/games/fish.js
@@ -1,7 +1,8 @@
 (function(g){
   const FISH_SET = ['🐳','🐋','🐬','🦭','🐟','🐠','🦈','🐙','🪼','🦀','🦞','🦐'];
   const FISH_MAX = 6;
-  const SPAWN_SECS = 0.6;
+  const SPAWN_DELAY_MIN = 0;
+  const SPAWN_DELAY_MAX = 3;
   const R_MIN = 25;
   const R_MAX = 90;
   const V_MIN = 10;
@@ -11,7 +12,8 @@
     max: FISH_MAX,
     emojis: FISH_SET,
     burst: ['🫧'],
-    spawnEvery: SPAWN_SECS,
+    spawnDelayMin: SPAWN_DELAY_MIN,
+    spawnDelayMax: SPAWN_DELAY_MAX,
     bounceY: true,
 
     spawn(){

--- a/games/mole.js
+++ b/games/mole.js
@@ -6,7 +6,8 @@
   const MOLE_COUNT = 12;
   const MOLE_EMOJIS = ['🐭','🐰'];
   const MOLE_ROWS = [3,2,3];
-  const SPAWN_SECS = 0.6;
+  const SPAWN_DELAY_MIN = 0;
+  const SPAWN_DELAY_MAX = 3;
 
   function buildGrid(game){
     const rows = MOLE_ROWS;
@@ -43,7 +44,8 @@
     max: MOLE_COUNT,
     emojis: MOLE_EMOJIS,
     burst: ['💫'],
-    spawnEvery: SPAWN_SECS,
+    spawnDelayMin: SPAWN_DELAY_MIN,
+    spawnDelayMax: SPAWN_DELAY_MAX,
 
     onStart(){
       buildGrid(this);


### PR DESCRIPTION
## Summary
- add `spawnDelayMin`/`spawnDelayMax` defaults in engine
- spawn logic now waits a random amount of time between spawns
- provide spawn delay settings in balloon, emoji, fish and mole configs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cea86fe80832c898be5931fd305dc