### PR TITLE
Restore wobble/sway effects

### DIFF
--- a/games/balloon.js
+++ b/games/balloon.js
@@ -29,7 +29,7 @@
       const y = this.H + r;
       const dx = g.R.between(-20, 20);
       const dy = -g.R.between(B_V_MIN, B_V_MAX);
-      const s = this.addSprite({ x, y, dx, dy, r, e });
+      const s = this.addSprite({ x, y, dx, dy, r, e, phase: g.R.rand(Math.PI * 2) });
       const hue = Math.random() * 360;
       const bri = g.R.between(BRIGHT_MIN, BRIGHT_MAX);
       const sat = g.R.between(SAT_MIN, SAT_MAX);
@@ -38,8 +38,9 @@
     },
 
     move(s, dt){
-      s.sway = (s.sway || 0) + dt * WOBBLE_FREQ;
-      s.x += s.dx * dt + Math.sin(s.sway) * WOBBLE_AMPL;
+      s.phase = (s.phase || 0) + dt * WOBBLE_FREQ;
+      s.x += s.dx * dt;
+      s.x += Math.sin(s.phase) * WOBBLE_AMPL;
       s.y += s.dy * dt;
     }
   }));

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -43,14 +43,14 @@
         r,
         e: g.R.pick(this.emojis),
         hp: 1,
-        wob: g.R.rand(Math.PI * 2)
+        phase: g.R.rand(Math.PI * 2)
       });
       return null;
     },
 
     move(s, dt) {
-      s.wob = (s.wob || 0) + dt * WOBBLE_FREQ;
-      s.y += Math.sin(s.wob) * WOBBLE_AMPL;
+      s.phase = (s.phase || 0) + dt * WOBBLE_FREQ;
+      s.y += Math.sin(s.phase) * WOBBLE_AMPL;
       s.x += s.dx * dt;
       s.y += s.dy * dt;
     }

--- a/games/fish.js
+++ b/games/fish.js
@@ -6,7 +6,9 @@
   const R_MIN = 25;
   const R_MAX = 90;
   const V_MIN = 10;
-  const V_MAX = 180;
+const V_MAX = 180;
+const WOBBLE_AMPL = 0.10;
+const WOBBLE_FREQ = 0.03;
 
   g.Game.register('fish', g.BaseGame.make({
     max: FISH_MAX,
@@ -23,12 +25,14 @@
       const y = g.R.between(r, this.H - r);
       const dx = (fromLeft ? 1 : -1) * g.R.between(V_MIN, V_MAX);
       const dy = g.R.between(-20, 20);
-      const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), hp:1 });
+      const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), hp:1, phase: g.R.rand(Math.PI * 2) });
       if (dx < 0) sp.el.style.scale = '-1 1';
       return null;
     },
 
     move(s, dt){
+      s.phase = (s.phase || 0) + dt * WOBBLE_FREQ;
+      s.y += Math.sin(s.phase) * WOBBLE_AMPL;
       s.x += s.dx * dt;
       s.y += s.dy * dt;
       if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;


### PR DESCRIPTION
## Summary
- restore emoji vertical wobble using `phase`
- add fish vertical wobble
- reintroduce balloon horizontal sway

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d16af8c98832cbc4cf8c862fe1ee2