### PR TITLE
Add fish pop CSS animation

### DIFF
--- a/games/fish.js
+++ b/games/fish.js
@@ -26,6 +26,7 @@ const WOBBLE_FREQ = 0.03;
       const dx = (fromLeft ? 1 : -1) * g.R.between(V_MIN, V_MAX);
       const dy = g.R.between(-20, 20);
       const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), hp:1, phase: g.R.rand(Math.PI * 2) });
+      sp.el.style.setProperty('--flyX', dx < 0 ? '-120vw' : '120vw');
       if (dx < 0) sp.el.style.scale = '-1 1';
       return null;
     },
@@ -36,9 +37,6 @@ const WOBBLE_FREQ = 0.03;
       s.x += s.dx * dt;
       s.y += s.dy * dt;
       if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;
-    },
-
-    onHit(_s){
     }
   }));
 })(window);

--- a/style.css
+++ b/style.css
@@ -329,14 +329,14 @@ input[type="range"] {
 }
 
 .game.fish .spawn { animation: fishSpawn 0.3s ease-out forwards; }
-.game.fish .pop   { animation: fishPop 0.2s ease-out forwards; }
+.game.fish .pop   { animation: fishPop 0.25s ease-out forwards; }
 
 @keyframes fishSpawn {
   from { transform: scale(0); opacity: 0; }
   to   { transform: scale(1); opacity: 1; }
 }
 @keyframes fishPop {
-  to { transform: scale(0); opacity: 0; }
+  to { transform: translateX(var(--flyX)) rotate(360deg); }
 }
 
 .game.mole .spawn { animation: moleRise 0.3s forwards; }


### PR DESCRIPTION
## Summary
- add fishPop keyframes for fly off animation
- use CSS animation for fish pop duration
- set CSS variable for fly direction when spawning fish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d2e3b9d88832c8c6e9da132a9dcba