### PR TITLE
Add error handling for MJPEG feed load failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -472,7 +472,11 @@ const Feeds = (() => {
     videoTop = new Image();
     videoTop.crossOrigin = 'anonymous';
     videoTop.src = cfg.url;
-    await videoTop.decode();
+    try {
+      await videoTop.decode();
+    } catch (err) {
+      throw new Error('Failed to load top camera feed');
+    }
 
     const frontStream = await navigator.mediaDevices.getUserMedia({
       audio: false,
@@ -764,7 +768,13 @@ const Controller = (() => {
 
   async function start() {
     Setup.bind();
-    await Feeds.init();
+    try {
+      await Feeds.init();
+    } catch (err) {
+      alert(err.message);
+      console.error('Feed initialization failed:', err);
+      return;
+    }
     await Detect.init();
     lastTop = 0;
     requestAnimationFrame(topLoop);


### PR DESCRIPTION
## Summary
- guard against MJPEG top camera feed failing to load
- show an alert if initialization of feeds fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d436fbc5c832c83c0e45ac4c42b9d