### PR TITLE
Ensure game layer exists before initialization

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -340,7 +340,12 @@ Game.run = target => {
   inst = new REG[i].cls();
   scoreAEl.textContent = '0';
   scoreBEl.textContent = '0';
-  const layer = document.getElementById('gameLayer') || document.body;
+  const layer = document.getElementById('gameLayer');
+  if (!layer) {
+    const msg = 'Game.run: missing element with id "gameLayer"';
+    console.error(msg);
+    throw new Error(msg);
+  }
   inst.init(layer);
   if (typeof inst.onStart === 'function') inst.onStart();
   const game = inst;


### PR DESCRIPTION
## Summary
- check for the presence of the `gameLayer` element when starting a game
- log and throw an error if the element is missing

## Testing
- `node -e "require('./game-engine.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d4b3eb7d4832c8a798ae147cc418b