### PR TITLE
Fix sprite spawn on game start

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -131,6 +131,12 @@ class BaseGame {
     this.container.className = 'game' + (this.gameName ? ' ' + this.gameName : '');
   }
 
+  /* ---- 3.2.1 spawn initial sprite(s) ---- */
+  start() {
+    const desc = this.spawn();
+    if (desc) this.addSprite(desc);
+  }
+
   /* ---- 3.3 main loop : called from rAF ---- */
   loop(dt) {
     if (this.sprites.length < this.cfg.max) {
@@ -348,6 +354,7 @@ Game.run = target => {
   }
   inst.init(layer);
   if (typeof inst.onStart === 'function') inst.onStart();
+  if (typeof inst.start === 'function') inst.start();
   const game = inst;
   let last = performance.now();
   (function frame(now) {


### PR DESCRIPTION
## Summary
- spawn an initial sprite when a new game is started
- call the new start method from `Game.run`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d47d50f54832ca7ea14bd57ec34f0