### PR TITLE
Fix spawn functions to return descriptors

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -179,6 +179,8 @@ class BaseGame {
   }
 
   /* ---- 3.4 factory : create + register a sprite ---- */
+  // desc.s → object of style properties (camelCase or kebab)
+  // desc.p → object of CSS custom properties (keys starting with --)
   addSprite(desc) {
     const r = desc.r ?? R.between(this.cfg.rMin, this.cfg.rMax);
     const speed = R.between(this.cfg.vMin, this.cfg.vMax);
@@ -191,6 +193,10 @@ class BaseGame {
     };
     const full = { hp: 1, ...otherDefaults, ...desc };
     const sprite = new Sprite(full);
+    if (desc.s) Object.assign(sprite.el.style, desc.s);
+    if (desc.p) {
+      for (const [k, v] of Object.entries(desc.p)) sprite.el.style.setProperty(k, v);
+    }
     if (desc.ttl !== undefined) sprite.ttl = desc.ttl;
     this.sprites.push(sprite);
     return sprite;

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -29,12 +29,20 @@
       const y = this.H + r;
       const dx = g.R.between(-20, 20);
       const dy = -g.R.between(B_V_MIN, B_V_MAX);
-      const s = this.addSprite({ x, y, dx, dy, r, e, phase: g.R.rand(Math.PI * 2) });
       const hue = Math.random() * 360;
       const bri = g.R.between(BRIGHT_MIN, BRIGHT_MAX);
       const sat = g.R.between(SAT_MIN, SAT_MAX);
-      s.el.style.filter = `hue-rotate(${hue}deg) brightness(${bri}) saturate(${sat})`;
-      return null;
+      const d = {
+        x,
+        y,
+        dx,
+        dy,
+        r,
+        e,
+        phase: g.R.rand(Math.PI * 2),
+        s: { filter: `hue-rotate(${hue}deg) brightness(${bri}) saturate(${sat})` }
+      };
+      return d;
     },
 
     move(s, dt){

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -35,7 +35,7 @@
       const ang = g.R.rand(Math.PI * 2);
       const vx = Math.cos(ang) * speed;
       const vy = Math.sin(ang) * speed;
-      this.addSprite({
+      const d = {
         x,
         y,
         dx: vx,
@@ -44,8 +44,8 @@
         e: g.R.pick(this.emojis),
         hp: 1,
         phase: g.R.rand(Math.PI * 2)
-      });
-      return null;
+      };
+      return d;
     },
 
     move(s, dt) {

--- a/games/fish.js
+++ b/games/fish.js
@@ -25,10 +25,19 @@ const WOBBLE_FREQ = 0.03;
       const y = g.R.between(r, this.H - r);
       const dx = (fromLeft ? 1 : -1) * g.R.between(V_MIN, V_MAX);
       const dy = g.R.between(-20, 20);
-      const sp = this.addSprite({ x, y, dx, dy, r, e: g.R.pick(this.emojis), hp:1, phase: g.R.rand(Math.PI * 2) });
-      sp.el.style.setProperty('--flyX', dx < 0 ? '-120vw' : '120vw');
-      if (dx < 0) sp.el.style.scale = '-1 1';
-      return null;
+      const d = {
+        x,
+        y,
+        dx,
+        dy,
+        r,
+        e: g.R.pick(this.emojis),
+        hp: 1,
+        phase: g.R.rand(Math.PI * 2),
+        p: { '--flyX': dx < 0 ? '-120vw' : '120vw' }
+      };
+      if (dx < 0) d.s = { scale: '-1 1' };
+      return d;
     },
 
     move(s, dt){

--- a/games/mole.js
+++ b/games/mole.js
@@ -54,7 +54,7 @@
       if(idx === -1) return null;
       const hole = this.holes[idx];
       hole.occupied = true;
-      const sp = this.addSprite({
+      const d = {
         x: hole.x,
         y: hole.y,
         dx: 0,
@@ -62,17 +62,16 @@
         r: this.holeR,
         e: g.R.pick(this.emojis),
         hp: 1,
-        ttl: MOLE_LIFETIME_SECS
-      });
-      sp.el.classList.add('mole');
-      sp.el.style.setProperty('--mole-h', `${this.holeR*2}px`);
-      sp.holeIndex = idx;
+        ttl: MOLE_LIFETIME_SECS,
+        p: { '--mole-h': `${this.holeR * 2}px` }
+      };
+      return d;
     },
 
 
     onHit(sp){
-      const hole = this.holes[sp.holeIndex];
-      if(hole) hole.occupied = false;
+      const idx = this.holes.findIndex(h => h.x === sp.x && h.y === sp.y);
+      if(idx >= 0) this.holes[idx].occupied = false;
     }
 
   }));


### PR DESCRIPTION
## Summary
- remove direct addSprite calls from spawn functions
- spawn functions now return sprite descriptors
- clean up unused return statements and DOM updates
- support inline style and CSS variables when spawning sprites

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d8f703df8832c9784432781ef0f25