### PR TITLE
Fix emoji spawn effect

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -57,7 +57,8 @@ class Sprite {
       width: `${size}px`,
       height: `${size}px`,
       lineHeight: `${size}px`,
-      fontSize: `${size}px`
+      fontSize: `${size}px`,
+      transform: 'translate3d(var(--x), var(--y), 0) scale(1)'
     });
 
     if (Sprite.layer) Sprite.layer.appendChild(this.el);
@@ -66,8 +67,8 @@ class Sprite {
   }
 
   draw() {
-    this.el.style.transform =
-      `translate3d(${this.x - this.r}px, ${this.y - this.r}px, 0) scale(1)`;
+    this.el.style.setProperty('--x', `${this.x - this.r}px`);
+    this.el.style.setProperty('--y', `${this.y - this.r}px`);
   }
 
   remove() {

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -28,7 +28,6 @@
     bounceY    : true,
 
     spawn() {
-      alert('emoji spawn');
       const r = g.R.between(R_MIN, R_MAX);
       const x = g.R.rand(this.W);
       const y = g.R.rand(this.H);

--- a/style.css
+++ b/style.css
@@ -207,6 +207,9 @@ input[type="range"] {
   justify-content: center;
   align-items: center;
   transform-origin: center;
+  --x: 0px;
+  --y: 0px;
+  transform: translate3d(var(--x), var(--y), 0) scale(1);
 }
 .emoji.mole {
   overflow: hidden;
@@ -310,8 +313,8 @@ input[type="range"] {
 .game.emoji .pop   { animation: emojiPop 0.2s ease-out forwards; }
 
 @keyframes emojiSpawn {
-  from { transform: scale(0); opacity: 0; }
-  to   { transform: scale(1); opacity: 1; }
+  from { transform: translate3d(var(--x), var(--y), 0) scale(0); opacity: 0; }
+  to   { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
 }
 @keyframes emojiPop {
   to { transform: scale(0); opacity: 0; }
@@ -321,8 +324,8 @@ input[type="range"] {
 .game.balloon .pop   { animation: balloonPop 0.2s ease-out forwards; }
 
 @keyframes balloonSpawn {
-  from { transform: scale(0); opacity: 0; }
-  to   { transform: scale(1); opacity: 1; }
+  from { transform: translate3d(var(--x), var(--y), 0) scale(0); opacity: 0; }
+  to   { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
 }
 @keyframes balloonPop {
   to { transform: translateY(-20px) scale(0); opacity: 0; }
@@ -332,8 +335,8 @@ input[type="range"] {
 .game.fish .pop   { animation: fishPop 0.25s ease-out forwards; }
 
 @keyframes fishSpawn {
-  from { transform: scale(0); opacity: 0; }
-  to   { transform: scale(1); opacity: 1; }
+  from { transform: translate3d(var(--x), var(--y), 0) scale(0); opacity: 0; }
+  to   { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
 }
 @keyframes fishPop {
   to { transform: translateX(var(--flyX)) rotate(360deg); }


### PR DESCRIPTION
## Summary
- remove leftover alert from emoji mode
- keep sprite positions stable during spawn animation
- maintain GPU acceleration using transform variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687e2f405c30832c97b523eccde28686