### PR TITLE
Fix fish removal timing

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -166,7 +166,12 @@ class BaseGame {
         if (right >= 0 && left <= this.W && bottom >= 0 && top <= this.H) {
           s.entered = true;
         }
-      } else if (right < 0 || left > this.W || bottom < 0 || top > this.H) {
+      } else if (
+        right < -s.r ||
+        left  > this.W + s.r ||
+        bottom < -s.r ||
+        top > this.H + s.r
+      ) {
         s.remove();
       }
     }

--- a/games/fish.js
+++ b/games/fish.js
@@ -45,7 +45,11 @@ const WOBBLE_FREQ = 0.03;
       s.y += Math.sin(s.phase) * WOBBLE_AMPL;
       s.x += s.dx * dt;
       s.y += s.dy * dt;
-      if((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) s.dy *= -1;
+      if ((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) {
+        s.dy *= -1;
+      }
+      if (s.y - s.r < 0) s.y = s.r;
+      if (s.y + s.r > this.H) s.y = this.H - s.r;
     }
   }));
 })(window);


### PR DESCRIPTION
## Summary
- tweak off-screen removal logic to wait until sprites are well outside the viewport
- clamp fish position after bounce so it doesn't get removed too early

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e447a8ef8832c8042f77050937eca