### PR TITLE
Update viewport width/height detection

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -96,11 +96,15 @@ class BaseGame {
   init(layer) {
     Sprite.layer = layer;                 // drawing parent
     this.container = layer;
-    this.W = window.innerWidth;
-    this.H = window.innerHeight;
+    this.winW = window.visualViewport.width || window.innerWidth;
+    this.winH = window.visualViewport.height || window.innerHeight;
+    this.W = this.winW;
+    this.H = this.winH;
     this._resize = () => {
-      this.W = window.innerWidth;
-      this.H = window.innerHeight;
+      this.winW = window.visualViewport.width || window.innerWidth;
+      this.winH = window.visualViewport.height || window.innerHeight;
+      this.W = this.winW;
+      this.H = this.winH;
     };
     window.addEventListener('resize', this._resize);
     window.addEventListener('orientationchange', this._resize);


### PR DESCRIPTION
## Summary
- prefer `visualViewport` when tracking window width and height in BaseGame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e8607ed14832caef385e029ee5382