### PR TITLE
Optimize sprite cleanup

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -216,7 +216,11 @@ class BaseGame {
       s.draw();
     }
 
-    this.sprites = this.sprites.filter(sp => sp.alive);
+    for (let i = this.sprites.length - 1; i >= 0; i--) {
+      if (!this.sprites[i].alive) {
+        this.sprites.splice(i, 1);
+      }
+    }
     if (this.running) this._raf = requestAnimationFrame(this._loop);
   }
 


### PR DESCRIPTION
## Summary
- remove dead sprites by splicing the array instead of filtering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f2fee0af4832c9988c71477112e50