### PR TITLE
Simplify sprite init and remove extraneous fields

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -19,13 +19,10 @@ win.R = R;
 const DEFAULT_BURST = ['✨', '💥', '💫'];
 
 const baseCfg = {
-  mode: 'emoji',
   max: 6,
   rRange: [25, 90],
   vRange: [10, 180],
-  spin: 25,
   burstN: 14,
-  particleLife: 1,
   burst: DEFAULT_BURST,
   winPoints     : 30,                  // first team to reach this wins
   spawnDelayRange : [0, 3],            // seconds [min,max]
@@ -225,17 +222,15 @@ class BaseGame {
   addSprite(desc) {
     const [rMin, rMax] = this.cfg.rRange;
     const [vMin, vMax] = this.cfg.vRange;
-    const r = desc.r ?? R.between(rMin, rMax);
+    desc.r ??= R.between(rMin, rMax);
     const speed = R.between(vMin, vMax);
     const ang = R.rand(Math.PI * 2);
-    const otherDefaults = {
-      r,
-      e: desc.e ?? R.pick(this.cfg.emojis || []),
-      dx: Math.cos(ang) * speed,
-      dy: Math.sin(ang) * speed
-    };
-    const full = { hp: 1, ...otherDefaults, ...desc };
-    const sprite = new Sprite(full);
+    desc.e ??= R.pick(this.cfg.emojis || []);
+    desc.dx = Math.cos(ang) * speed;
+    desc.dy = Math.sin(ang) * speed;
+
+    const sprite = new Sprite(desc);
+    sprite.hp = 1;
     if (desc.s) Object.assign(sprite.style, desc.s);
     if (desc.p) {
       for (const [k, v] of Object.entries(desc.p)) sprite.style.setProperty(k, v);
@@ -267,7 +262,6 @@ class BaseGame {
   }
 
   _resolveCollisions() {
-    if (!this.cfg.collisions) return;
     const len = this.sprites.length;
     for (let i = 0; i < len; i++) {
       const a = this.sprites[i];

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -37,8 +37,7 @@
         dx: vx,
         dy: vy,
         r,
-        e: g.R.pick(this.emojis),
-        hp: 1
+        e: g.R.pick(this.emojis)
       };
       return d;
     },

--- a/games/fish.js
+++ b/games/fish.js
@@ -27,7 +27,6 @@
         dy,
         r,
         e: g.R.pick(this.emojis),
-        hp: 1,
         scaleX: swimRight ? -1 : 1,
         p: { '--flyX': swimRight ? '120vw' : '-120vw' }
       };

--- a/games/mole.js
+++ b/games/mole.js
@@ -59,8 +59,8 @@
         dy: 0,
         r: this.holeR,
         e: g.R.pick(this.emojis),
-        hp: 1,
         ttl: MOLE_LIFETIME_SECS,
+        holeIndex: idx,
         p: { '--mole-h': `${this.holeR * 2}px` }
       };
       return d;
@@ -68,8 +68,8 @@
 
 
     onHit(sp){
-      const idx = this.holes.findIndex(h => h.x === sp.x && h.y === sp.y);
-      if(idx >= 0) this.holes[idx].occupied = false;
+      const idx = sp.holeIndex;
+      if(idx !== undefined) this.holes[idx].occupied = false;
     }
 
   }));


### PR DESCRIPTION
## Summary
- compute spawn defaults directly on the descriptor
- drop unused config and redundant collision guard
- avoid searching for hole slot on mole hit

## Testing
- `node -c game-engine.js`
- `node -c games/emoji.js`
- `node -c games/fish.js`
- `node -c games/mole.js`


------
https://chatgpt.com/codex/tasks/task_e_687f40623a8c832ca044bbdc8dfa74f4