### PR TITLE
Fix fish bouncing

### DIFF
--- a/games/fish.js
+++ b/games/fish.js
@@ -36,11 +36,6 @@
     move(s, dt){
       s.x += s.dx * dt;
       s.y += s.dy * dt;
-      if ((s.y - s.r < 0 && s.dy < 0) || (s.y + s.r > this.H && s.dy > 0)) {
-        s.dy *= -1;
-      }
-      if (s.y - s.r < 0) s.y = s.r;
-      if (s.y + s.r > this.H) s.y = this.H - s.r;
     }
   }));
 })(window);


### PR DESCRIPTION
## Summary
- remove vertical bounce logic from fish.move()
- rely on BaseGame bounceY behavior instead

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f51443b80832cb658b4797dfdcdbf