### PR TITLE
Tune object movement directions

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -205,8 +205,8 @@ class BaseGame {
     const speed = R.between(vMin, vMax);
     const ang = R.rand(Math.PI * 2);
     desc.e ??= R.pick(this.cfg.emojis || []);
-    desc.dx = Math.cos(ang) * speed;
-    desc.dy = Math.sin(ang) * speed;
+    desc.dx ??= Math.cos(ang) * speed;
+    desc.dy ??= Math.sin(ang) * speed;
 
     const sprite = new Sprite(desc);
     if (desc.s) Object.assign(sprite.style, desc.s);

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -21,7 +21,7 @@
       const e = rare ? g.R.pick(BALLOON_RARE) : BALLOON_SET[0];
       const x = g.R.between(r, this.W - r);
       const y = this.H + r;
-      const dx = g.R.between(-20, 20);
+      const dx = g.R.between(-10, 10);
       const dy = -g.R.between(...B_V_RANGE);
       const hue = Math.random() * 360;
       const bri = g.R.between(...BRIGHT_RANGE);

--- a/games/fish.js
+++ b/games/fish.js
@@ -19,7 +19,7 @@
       const dx = swimRight ? speed : -speed;
       const x = swimRight ? -r : this.W + r;
       const y = g.R.between(r, this.H - r);
-      const dy = g.R.between(-20, 20);
+      const dy = g.R.between(-10, 10);
       const d = {
         x,
         y,


### PR DESCRIPTION
## Summary
- keep custom velocities when sprites spawn
- reduce balloon horizontal drift
- reduce fish vertical drift

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880246d63dc832c881b8082c13faa2b