### PR TITLE
Fix burst method call in pop animation

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -302,10 +302,10 @@ class BaseGame {
     s.style.setProperty('--x', `${s.x - s.r}px`);
     s.style.setProperty('--y', `${s.y - s.r}px`);
     s.el.classList.add('pop');
-    this.burst(s.x, s.y);
+    this.emitBurst(s.x, s.y);
   }
 
-  burst(x, y, emojiArr = this.cfg.burst) {
+  emitBurst(x, y, emojiArr = this.cfg.burst) {
     for (let i = 0; i < this.cfg.burstN; i++) {
       const sp = 150 + R.rand(150);
       const ang = R.rand(Math.PI * 2);


### PR DESCRIPTION
## Summary
- rename `burst` method to `emitBurst`
- call the renamed method when a sprite pops

This avoids the config option `burst` overwriting the method and fixes
`this.burst is not a function` errors.

## Testing
- `node --check game-engine.js`

------
https://chatgpt.com/codex/tasks/task_e_688064f17b84832cb1afb3ab5be2d9c7