### PR TITLE
Fix right-click team mapping

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -287,7 +287,7 @@ class BaseGame {
     this._showRipple(x, y);
     for (const s of this.sprites) {
       if ((x - s.x) ** 2 + (y - s.y) ** 2 <= s.r ** 2) {
-        this.hit(s, btn === 2 ? 1 : 0);
+        this.hit(s, btn === 2 ? 0 : 1);
         break;
       }
     }


### PR DESCRIPTION
## Summary
- fix team index for right-click in `game-engine.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881e226a084832c8c1bfe13c22659d3