### PR TITLE
Switch to reusable burst element

### DIFF
--- a/style.css
+++ b/style.css
@@ -238,14 +238,18 @@ input[type="range"] {
 
 .burst {
   position: absolute;
-  font-family: sans-serif;
-  font-size: 48px;
-  text-align: center;
-  line-height: 1;
   pointer-events: none;
-  user-select: none;
+}
+
+.burst p {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-family: sans-serif;
+  font-size: 24px;
+  line-height: 1;
   will-change: transform, opacity;
-  animation: pop 1s ease-out forwards;
+  animation: particleMove var(--life, 1s) linear forwards;
 }
 
 /* ripple */


### PR DESCRIPTION
## Summary
- implement a single `.burst` element with 14 `<p>` particles
- animate each particle via CSS `particleMove` and drive reuse in JS
- update BaseGame to create and manage its own burst element
- simplify boot logic and remove burst template

## Testing
- `node -e "require('./game-engine.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6881f2c5a3d4832ca79ecfdefb6fda0f