### PR TITLE
Fix right-click hits

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -381,6 +381,7 @@ function boot() {
     g.onPointer(e.clientX - r.left, e.clientY - r.top, e.button);
   });
   layer.addEventListener('contextmenu',  e => e.preventDefault());
+  window.addEventListener('contextmenu', e => e.preventDefault());
   layer.addEventListener('animationend', e => inst?._onAnimEnd?.(e));
 }
 


### PR DESCRIPTION
## Summary
- prevent context menus globally so right-click hits register

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688263027cac832c8ff31a9fb276edf7