### PR TITLE
Add hit and miss hooks to game engine

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -146,11 +146,11 @@ class BaseGame {
         bottom < -s.r ||
         top > this.H + s.r
       ) {
-        s.remove();
+        this.miss(s);
       }
 
       if (s.ttl !== undefined && (s.ttl -= dt) <= 0) {
-        this._popSprite(s);
+        this.miss(s);
       }
 
       if (s.alive) s.draw();
@@ -259,11 +259,18 @@ class BaseGame {
 
   /* ---- 3.7 HIT entry point ---- */
   hit(s, team = 0) {
+    if (typeof this.onHit === 'function') this.onHit(s, team);
     this.score[team] += this.calculatePoints(s);
     scoreEl[team].textContent = `${this.score[team]}`;
     this.emitBurst(s.x, s.y);
     this._popSprite(s);
     if (this.score[team] >= this.cfg.winPoints) this.end(team);
+  }
+
+  /* ---- 3.7b MISS entry point ---- */
+  miss(s) {
+    if (typeof this.onMiss === 'function') this.onMiss(s);
+    this._popSprite(s);
   }
 
   /* ---- 3.8 POP animation ---- */
@@ -272,7 +279,6 @@ class BaseGame {
     s.el.classList.remove('spawn');
     s.style.setProperty('--x', `${s.x - s.r}px`);
     s.style.setProperty('--y', `${s.y - s.r}px`);
-    if (typeof inst.onPop === 'function') inst.onPop(s);
     s.el.classList.add('pop');
   }
 

--- a/games/mole.js
+++ b/games/mole.js
@@ -78,7 +78,12 @@
     },
 
 
-    onPop(sp){
+    onHit(sp, team){
+      const idx = sp.holeIndex;
+      if(idx !== undefined) this.holes[idx].occupied = false;
+    },
+
+    onMiss(sp){
       const idx = sp.holeIndex;
       if(idx !== undefined) this.holes[idx].occupied = false;
     }


### PR DESCRIPTION
## Summary
- trigger sprite miss when off-screen or TTL expires
- add `onHit` and `onMiss` hooks and call them from the engine
- adjust mole game to free holes via new hooks

## Testing
- `node --check game-engine.js`
- `node --check games/mole.js`
- `node --check games/emoji.js`
- `node --check games/fish.js`
- `node --check games/balloon.js`


------
https://chatgpt.com/codex/tasks/task_e_68834ad7d570832c8f9c3550cad75e05