### PR TITLE
Improve fruit drop animation with CSS

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -41,11 +41,7 @@
 
     onHit(sp, team) {
       sp.hitTeam = team;
-      sp.el.addEventListener('animationend', e => {
-        if (e.target.classList.contains('pop')) {
-          this._afterPop(sp, team);
-        }
-      }, { once: true });
+      this._afterPop(sp, team);
     },
 
     _afterPop(sp, team = 0) {
@@ -61,7 +57,7 @@
         this.grid[r][col]     = null;
         mover.row  = r + 1;
         mover.y    = this.cell.y(r + 1);
-        mover.draw();
+        mover.el.classList.add('shiftDown');
       }
 
       const fresh = this.addSprite({
@@ -71,6 +67,7 @@
       });
       fresh.col = col;
       fresh.row = 0;
+      fresh.el.classList.add('dropIn');
       this.grid[0][col] = fresh;
 
       this._checkMatches(team);

--- a/style.css
+++ b/style.css
@@ -359,3 +359,21 @@ input[type="range"] {
 @keyframes fruitPop {
   to { transform: scale(0); opacity: 0; }
 }
+
+@keyframes slideDown {
+  from { transform: translateY(0); }
+  to   { transform: translateY(100%); }
+}
+
+.shiftDown {
+  animation: slideDown 0.2s ease-out 0.2s forwards;
+}
+
+@keyframes dropIn {
+  from { transform: translateY(-100%); }
+  to   { transform: translateY(0); }
+}
+
+.dropIn {
+  animation: dropIn 0.2s ease-out 0.2s forwards;
+}


### PR DESCRIPTION
## Summary
- remove JS animationend listeners from the fruits mode
- animate column shifts and new fruit drops using CSS classes

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688489447c88832cadbf272826078f31