### PR TITLE
Fix fruits column slide animation

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -53,10 +53,16 @@
       for (let r = row - 1; r >= 0; r--) {
         const mover = this.grid[r][col];
         if (!mover) continue;
-        this.grid[r + 1][col] = mover;
-        this.grid[r][col]     = null;
-        mover.row  = r + 1;
-        mover.y    = this.cell.y(r + 1);
+        let dest = r;
+        while (dest + 1 < ROWS && this.grid[dest + 1][col] === null) dest++;
+        if (dest === r) continue;
+        this.grid[dest][col] = mover;
+        this.grid[r][col]    = null;
+        mover.row = dest;
+        mover.y   = this.cell.y(dest);
+        mover.style.setProperty('--dist', `${(dest - r) * 100}%`);
+        mover.el.classList.remove('shiftDown');
+        void mover.el.offsetWidth;
         mover.el.classList.add('shiftDown');
       }
 

--- a/style.css
+++ b/style.css
@@ -362,7 +362,7 @@ input[type="range"] {
 
 @keyframes slideDown {
   from { transform: translate3d(var(--x), var(--y), 0) translateY(0); }
-  to   { transform: translate3d(var(--x), var(--y), 0) translateY(100%); }
+  to   { transform: translate3d(var(--x), var(--y), 0) translateY(var(--dist, 100%)); }
 }
 
 .shiftDown {


### PR DESCRIPTION
## Summary
- improve column drop logic in fruits game so sprites move multiple slots
- allow CSS slideDown animation to use variable distance

## Testing
- `node -c games/fruits.js`

------
https://chatgpt.com/codex/tasks/task_e_68848dbda748832cb3c31e38e521ac8e