### PR TITLE
Add smooth slide down for new fruit

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -73,15 +73,39 @@
         mover.draw();
       }
 
+      /* ───────────────────────────────────────────────────────────
+         Spawn ONE new fruit and let CSS slide it all the way down
+         -----------------------------------------------------------
+         1. Find the lowest empty slot in this column.
+         2. If that slot = row 0 → keep the old “drop-in” effect.
+            Otherwise skip .dropIn and give the sprite the same
+            transform-transition we just used for the movers above.
+      ─────────────────────────────────────────────────────────── */
+
+      let target = 0;
+      while (target + 1 < ROWS && this.grid[target + 1][col] === null) target++;
+
       const fresh = this.addSprite({
-        x:this.cell.x(col), y:this.cell.y(0),
+        x:this.cell.x(col), y:this.cell.y(0),   // visual start position
         dx:0, dy:0, r:this.cell.r,
         e:g.R.pick(this.emojis)
       });
       fresh.col = col;
-      fresh.row = 0;
-      fresh.el.classList.add('dropIn');
-      this.grid[0][col] = fresh;
+
+      if (target === 0) {
+        /* only the very top cell was empty → classic drop-in */
+        fresh.row = 0;
+        this.grid[0][col] = fresh;
+        fresh.el.classList.add('dropIn');
+      } else {
+        /* more space underneath → glide down with a transform tween */
+        fresh.row = target;
+        fresh.y   = this.cell.y(target);
+        this.grid[target][col] = fresh;          // final logical slot
+
+        fresh.style.transition = 'transform 0.25s ease-out';
+        fresh.draw();                            // kicks off the slide
+      }
 
       this._checkMatches(team);
     },


### PR DESCRIPTION
## Summary
- update fruits game logic so new fruit finds the lowest open slot
- if that slot is row 0, keep existing drop-in animation
- otherwise, place sprite directly in its target row and slide down with CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884f00f1b5c832c891e9b892ec9ed00