### PR TITLE
Add onSpriteAlive hook and refactor fruits game

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -328,6 +328,10 @@ class BaseGame {
       if (this.running && sp.alive !== false) {
         this.sprites.push(sp);
         sp.draw();
+        /* public hook — lets a game know the sprite is ready */
+        if (typeof this.onSpriteAlive === 'function') {
+          this.onSpriteAlive(sp);
+        }
       }
     } else if (el.classList.contains('pop')) {
       sp.remove();


### PR DESCRIPTION
## Summary
- notify games when sprites finish spawning using `onSpriteAlive`
- rebuild the Fruits game around regular `spawn()` flow
- handle cascade/refill logic directly in `fruits.js`

## Testing
- `node -e "require('fs').readFileSync('games/fruits.js','utf8')" > /dev/null && echo 'ok'`

------
https://chatgpt.com/codex/tasks/task_e_68850a7e3104832cbedc3af81ffa87be