### PR TITLE
Add alert hooks to trace fruit slide chain

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -328,6 +328,7 @@ class BaseGame {
       if (this.running && sp.alive !== false) {
         this.sprites.push(sp);
         sp.draw();
+        alert(`hook → onSpriteAlive: ${sp.e || sp.id}`);
         /* public hook — lets a game know the sprite is ready */
         if (typeof this.onSpriteAlive === 'function') {
           this.onSpriteAlive(sp);

--- a/games/fruits.js
+++ b/games/fruits.js
@@ -51,6 +51,7 @@
 
     /* new engine hook from _onAnimEnd */
     onSpriteAlive (sp) {
+      alert(`alive ${sp.e} at ${sp.row},${sp.col}`);
       sp.row = sp._row;
       sp.col = sp._col;
       delete sp._row; delete sp._col;
@@ -63,6 +64,7 @@
     },
 
     _collapseColumn (col, fromRow) {
+      alert(`collapse column=${col} fromRow=${fromRow}`);
       if (col == null || fromRow == null) return;
       this.grid[fromRow][col] = null;          /* remove the popped fruit */
 
@@ -70,6 +72,7 @@
       for (let r = fromRow - 1; r >= 0; r--) {
         const sp = this.grid[r][col];
         if (!sp) continue;
+        alert(`falling ${sp.e} to row ${sp.row}`);
         this.grid[r + 1][col] = sp;
         this.grid[r][col]     = null;
         sp.row = r + 1;
@@ -84,6 +87,7 @@
 
     /* make falling fruits glide until they reach .targetY */
     move (sp, dt) {
+      alert(`move ${sp.e} y=${sp.y.toFixed(1)} dy=${sp.dy}`);
       if (sp.falling) {
         sp.y += sp.dy * dt;
         if (sp.y >= sp.targetY) {


### PR DESCRIPTION
## Summary
- add alert to BaseGame `_onAnimEnd` spawn branch
- add alerts in Fruits game to monitor sprite life cycle and collapse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68852bf9ae50832c8f5e6e7eb97d454b