### PR TITLE
Add debug alerts for fruit states

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -328,7 +328,7 @@ class BaseGame {
       if (this.running && sp.alive !== false) {
         this.sprites.push(sp);
         sp.draw();
-        alert(`hook → onSpriteAlive: ${sp.e || sp.id}`);
+        alert(`ALIVE ${sp.e} grid?=${!!sp.row}`);
         /* public hook — lets a game know the sprite is ready */
         if (typeof this.onSpriteAlive === 'function') {
           this.onSpriteAlive(sp);

--- a/games/fruits.js
+++ b/games/fruits.js
@@ -51,7 +51,7 @@
 
     /* new engine hook from _onAnimEnd */
     onSpriteAlive (sp) {
-      alert(`alive ${sp.e} at ${sp.row},${sp.col}`);
+      alert(`GRID-INSERT ${sp.e} ${sp.row},${sp.col}`);
       sp.row = sp._row;
       sp.col = sp._col;
       delete sp._row; delete sp._col;
@@ -64,7 +64,7 @@
     },
 
     _collapseColumn (col, fromRow) {
-      alert(`collapse column=${col} fromRow=${fromRow}`);
+      alert(`COLLAPSE col=${col} fromRow=${fromRow}`);
       if (col == null || fromRow == null) return;
       this.grid[fromRow][col] = null;          /* remove the popped fruit */
 
@@ -72,13 +72,14 @@
       for (let r = fromRow - 1; r >= 0; r--) {
         const sp = this.grid[r][col];
         if (!sp) continue;
-        alert(`falling ${sp.e} to row ${sp.row}`);
         this.grid[r + 1][col] = sp;
         this.grid[r][col]     = null;
         sp.row = r + 1;
         sp.targetY = this.cell.y(sp.row);   /* where it must stop */
         sp.falling = true;
+        alert(`FALL-TAG ${sp.e} newRow=${sp.row} dy=${sp.dy}`);
         sp.dy = this.dropSpeed;             /* engine’s move() will use this */
+
       }
 
       /* top cell now empty → ask engine for a fresh fruit */
@@ -87,14 +88,15 @@
 
     /* make falling fruits glide until they reach .targetY */
     move (sp, dt) {
-      alert(`move ${sp.e} y=${sp.y.toFixed(1)} dy=${sp.dy}`);
       if (sp.falling) {
+        alert(`MOVE ${sp.e} y=${sp.y.toFixed(1)} dy=${sp.dy}`);
         sp.y += sp.dy * dt;
         if (sp.y >= sp.targetY) {
           sp.y = sp.targetY;
           sp.dy = 0;
           sp.falling = false;
           delete sp.targetY;
+          alert(`LANDED ${sp.e} at ${sp.row},${sp.col}`);
         }
       }
     },


### PR DESCRIPTION
## Summary
- update engine _onAnimEnd to show ALIVE popup
- log GRID-INSERT events when fruits are added
- log COLLAPSE and FALL-TAG events for falling fruits
- show MOVE and LANDED popups while fruits fall

## Testing
- `node -e "console.log('no tests specified')"`


------
https://chatgpt.com/codex/tasks/task_e_6885312f4254832cb55a2c5a4ecf557f