### PR TITLE
Preserve sprite descriptor props

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -185,8 +185,9 @@ class BaseGame {
     if (desc.p) {
       for (const [k, v] of Object.entries(desc.p)) sprite.style.setProperty(k, v);
     }
-    if (desc.ttl !== undefined) sprite.ttl = desc.ttl;
-    if (desc.holeIndex !== undefined) sprite.holeIndex = desc.holeIndex;
+
+    /* preserve all descriptor properties */
+    Object.assign(sprite, desc);
 
     return sprite;
   }


### PR DESCRIPTION
## Summary
- keep all properties from a sprite descriptor when spawning sprites

## Testing
- `node -c game-engine.js`
- `node -c game.js`
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_688542ead940832c90cc684d99136b87