### PR TITLE
Fix fruit grid update on hit

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -59,6 +59,9 @@
     },
 
     onHit (sp, team) {
+      if (this.grid[sp.row] && this.grid[sp.row][sp.col] === sp) {
+        this.grid[sp.row][sp.col] = null;
+      }
       this._collapseColumn(sp.col, sp.row);
       this._checkMatches(team);
     },


### PR DESCRIPTION
## Summary
- clear fruit slot from grid before collapsing column so hits work again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688603837f5c832c8136e7f604fb432c