### PR TITLE
Modify pop animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -357,7 +357,8 @@ input[type="range"] {
   to   { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
 }
 @keyframes fruitPop {
-  to { transform: scale(0); opacity: 0; }
+  from { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
+  to   { transform: translate3d(var(--x), var(--y), 0) scale(1.5); opacity: 0; }
 }
 
 @keyframes slideDown {


### PR DESCRIPTION
## Summary
- revert modifications to emoji, balloon, and fish pop effects
- keep the fruit pop effect scaling up before vanishing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886064aaa30832c99e5448f60164f3d