### PR TITLE
Handle sprite registration when spawned

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -58,11 +58,19 @@
         row : r,
         col : c
       };
-      this.grid[r][c] = sp;        /* board knows the fruit immediately */
       return sp;
     },
 
-    onSpriteAlive () {},          /* already registered in spawn() */
+    onSpriteAlive (sp) {
+      /* NOW register the *actual* Sprite instance */
+      this.grid[sp.row][sp.col] = sp;
+
+      /* If the board is stable (no falling pieces, no queued spawns),
+         look for cascades that the new fruit may complete. */
+      if (!this.pending.length && !this.sprites.some(s => s.falling)) {
+        this._checkMatches(this.lastTeam || 0);
+      }
+    },
 
     onHit (sp, team) {
       /* remember the team so cascades score correctly */


### PR DESCRIPTION
## Summary
- fix spawn so board registers sprite when alive
- trigger match scanning when board is stable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68865645e9e4832c8b4307d8388abffe