### PR TITLE
Fix cascade detection when fruits spawn

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -259,13 +259,17 @@ class BaseGame {
   }
 
   /* ---- 3.7 HIT entry point ---- */
-  hit(s, team = 0) {
+  hit(s, team) {
     if (typeof this.onHit === 'function') this.onHit(s, team);
-    this.score[team] += this.calculatePoints(s);
-    scoreEl[team].textContent = `${this.score[team]}`;
+    if (team === 0 || team === 1) {
+      this.score[team] += this.calculatePoints(s);
+      scoreEl[team].textContent = `${this.score[team]}`;
+    }
     this.emitBurst(s.x, s.y);
     this._popSprite(s);
-    if (this.score[team] >= this.cfg.winPoints) this.end(team);
+    if ((team === 0 || team === 1) && this.score[team] >= this.cfg.winPoints) {
+      this.end(team);
+    }
   }
 
   /* ---- 3.7b MISS entry point ---- */

--- a/games/fruits.js
+++ b/games/fruits.js
@@ -70,6 +70,9 @@
     /* new engine hook from _onAnimEnd */
     onSpriteAlive (sp) {
       this.grid[sp.holeIndex] = sp;
+      if (!this.pending.length && !this.sprites.some(s => s.falling)) {
+        this._checkMatches(this.lastTeam);
+      }
     },
 
     onHit (sp, team) {
@@ -136,13 +139,13 @@
 
           /* when the LAST fruit settles, check for cascades */
           if (!this.sprites.some(s => s.falling)) {
-            this._checkMatches(this.lastTeam || 0);
+            this._checkMatches(this.lastTeam);
           }
         }
       }
     },
 
-    _checkMatches (team = 0) {
+    _checkMatches (team) {
       let matches;
       do {
         matches = new Set();


### PR DESCRIPTION
## Summary
- update fruits onSpriteAlive hook to check for matches after spawning
- avoid awarding points if no team is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68865c3ad300832c8e9dbe2e2ac35d2e