### PR TITLE
Fix cascade timing check in fruits

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -70,9 +70,6 @@
     /* new engine hook from _onAnimEnd */
     onSpriteAlive (sp) {
       this.grid[sp.holeIndex] = sp;
-      if (!this.pending.length && !this.sprites.some(s => s.falling)) {
-        this._checkMatches(this.lastTeam);
-      }
     },
 
     onHit (sp, team) {


### PR DESCRIPTION
## Summary
- remove `onSpriteAlive` check for matches

## Testing
- `node -e "require('./games/fruits.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6886682245d4832ca711dd4b0223d273