### PR TITLE
Fix fruit slot reservation at spawn time

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -57,7 +57,7 @@
       this.pendingSet.delete(idx);
       const r = rowFromIndex(idx);
       const c = colFromIndex(idx);
-      return {
+      const desc = {
         x : this.cell.x(c),
         y : this.cell.y(r),
         dx : 0, dy : 0,
@@ -65,6 +65,8 @@
         e  : g.R.pick(this.emojis),
         holeIndex : idx                   /* kept by addSprite → Sprite */
       };
+      this.grid[idx] = desc;             /* reserve the slot immediately */
+      return desc;
     },
 
     /* new engine hook from _onAnimEnd */


### PR DESCRIPTION
## Summary
- reserve the grid slot immediately when spawning fruits

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68866ac7c140832ca027d898f6614063