### PR TITLE
Fix pendingSet cleanup timing in fruits game

### DIFF
--- a/games/fruits.js
+++ b/games/fruits.js
@@ -54,7 +54,6 @@
     spawn () {
       const idx = this.pending.pop();
       if (idx === undefined) return null;
-      this.pendingSet.delete(idx);
       const r = rowFromIndex(idx);
       const c = colFromIndex(idx);
       const desc = {
@@ -71,6 +70,7 @@
 
     /* new engine hook from _onAnimEnd */
     onSpriteAlive (sp) {
+      this.pendingSet.delete(sp.holeIndex);
       this.grid[sp.holeIndex] = sp;
     },
 


### PR DESCRIPTION
## Summary
- update fruits game logic to remove pendingSet entries when sprites become active

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886706e7658832cb16e55630ca8e1d3