### PR TITLE
Fix gem reveal using onHit hook

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -260,7 +260,10 @@ class BaseGame {
 
   /* ---- 3.7 HIT entry point ---- */
   hit(s, team) {
-    if (typeof this.onHit === 'function') this.onHit(s, team);
+    if (typeof this.onHit === 'function') {
+      const handled = this.onHit(s, team);
+      if (handled === true) return;
+    }
     if (team === 0 || team === 1) {
       this.score[team] += this.calculatePoints(s);
       scoreEl[team].textContent = `${this.score[team]}`;

--- a/games/gem.js
+++ b/games/gem.js
@@ -29,16 +29,16 @@
       };
     },
 
-    /* reveal logic – skip base scoring / popping until fully revealed */
+    /* reveal logic – skip default scoring until fully revealed */
     onHit(s /* sprite */, team) {
       s.hits = (s.hits || 0) + 1;
       if (s.hits < MAX_HITS) {
         const pct = (s.hits / MAX_HITS * 100).toFixed(1) + '%';
         s.style.setProperty('--mr', pct);
-        /* <<< returning true tells the engine we handled the hit; no pop */
-        return true;
+        this.emitBurst(s.x, s.y, BURST);
+        return true;                  // tell engine we handled the hit
       }
-      /* once hits === MAX_HITS we fall through → engine scores & pops */
+      // let the engine proceed with normal scoring & pop
     }
   }));
 })(window);

--- a/style.css
+++ b/style.css
@@ -219,6 +219,7 @@ input[type="range"] {
 
 .gem .sprite {
   mask-image: radial-gradient(circle at 50% 50%, white 0%, white var(--mr), black var(--mr), black 50%);
+  -webkit-mask-image: radial-gradient(circle at 50% 50%, white 0%, white var(--mr), black var(--mr), black 50%);
 }
 
 .particle {


### PR DESCRIPTION
## Summary
- allow `BaseGame.onHit` to cancel default scoring/pop when returning `true`
- implement gem reveal logic in the onHit hook
- keep mask compatibility using `-webkit-mask-image`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875e02ef3c832c90f6443efd3c8a01