### PR TITLE
Add random rotation to gem spawns

### DIFF
--- a/games/gem.js
+++ b/games/gem.js
@@ -22,6 +22,7 @@
         dy: 0,
         e : g.R.pick(this.emojis),
         hits: 0,
+        angle: g.R.between(-Math.PI * 2, Math.PI * 2),
         p : { '--mr': '0%' }
       };
     },


### PR DESCRIPTION
## Summary
- spin gem emojis randomly when they spawn

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68878bb4b2c0832cb1576ed59e6b406d