### PR TITLE
Fix leftover elements when switching games

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -388,9 +388,6 @@ function boot() {
   window.addEventListener('resize', updateViewport, { passive: true });
   window.addEventListener('orientationchange', updateViewport, { passive: true });
 
-  Game.ripple = document.createElement('div');
-  Game.ripple.className = 'ripple';
-  layer.append(Game.ripple);
 
   layer.addEventListener('pointerdown', e => {
     const g = inst;
@@ -414,6 +411,15 @@ const REG = [];
 let idx = -1;
 let inst = null;
 
+function cleanupLayer() {
+  const layer = Game.layer;
+  if (!layer) return;
+  while (layer.firstChild) layer.firstChild.remove();
+  layer.className = '';
+  layer.removeAttribute('style');
+  Game.ripple = null;
+}
+
 Game.register = (id, cls) => {
   cls.prototype.gameName = id;
   REG.push({ id, cls });
@@ -436,6 +442,10 @@ Game.run = (target, opts = {}) => {
       : REG.findIndex(e => e.id === target);
   if (i < 0) return;
   if (inst) inst.end();
+  cleanupLayer();
+  Game.ripple = document.createElement('div');
+  Game.ripple.className = 'ripple';
+  Game.layer.append(Game.ripple);
   idx = i;
   inst = new REG[i].cls();
 


### PR DESCRIPTION
## Summary
- remove DOM elements from the previous game instance
- reset inline styles and classes on the game container
- recreate ripple effect on each run

## Testing
- `node -c game-engine.js`
- `node -c app.js`
- `node -c game.js`
- `node -c screen.js`


------
https://chatgpt.com/codex/tasks/task_e_68879c96e1c4832c866d764581625c50