### PR TITLE
Optimize layer cleanup

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -414,7 +414,9 @@ let inst = null;
 function cleanupLayer() {
   const layer = Game.layer;
   if (!layer) return;
-  while (layer.firstChild) layer.firstChild.remove();
+  // Using replaceChildren clears all nodes in a single operation
+  // which is faster than repeatedly removing firstChild
+  layer.replaceChildren();
   layer.className = '';
   layer.removeAttribute('style');
   Game.ripple = null;


### PR DESCRIPTION
## Summary
- improve layer cleanup performance using `replaceChildren`

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887c62c6858832cb420502444d9d60f