### PR TITLE
Remove pinata positioning styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -446,15 +446,6 @@ input[type="range"] {
 
 /* === Piñata animation === */
 .sprite.pinata {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  width: var(--size);
-  height: var(--size);
-  font-size: var(--size);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   transform-origin: 50% calc(-1*var(--string));
 }
 


### PR DESCRIPTION
## Summary
- clean up `.sprite.pinata` by removing fixed positioning styles

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a3a4879b8832c83932af392e6d5d4