### PR TITLE
Add event-based spawn queue to engine

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -88,6 +88,7 @@ class BaseGame {
     this._raf = null;
     this._spawnElapsed = 0;
     this._nextSpawn = R.between(...this.cfg.spawnDelayRange);
+    this._spawnQueue = [];              // ← NEW  event-driven queue
 
     this.burstEl = document.createElement('div');
     this.burstEl.className = 'burst';
@@ -126,6 +127,11 @@ class BaseGame {
         const desc = this.spawn();
         if (desc) this.addSprite(desc);
       }
+    }
+    /* 2.  event-driven spawns — drain the queue */
+    if (this._spawnQueue.length){
+      for (const desc of this._spawnQueue) this.addSprite(desc);
+      this._spawnQueue.length = 0;
     }
     for (let i = len - 1; i >= 0; i--) {
       const s = this.sprites[i];
@@ -194,6 +200,12 @@ class BaseGame {
 
   spawn() {
     return { x: R.rand(this.W), y: R.rand(this.H) };
+  }
+
+  /* ------------------------------------------------------------
+   *  Public helper: enqueue a descriptor to appear next frame  */
+  queueSpawn(desc){
+    this._spawnQueue.push(desc);
   }
 
   /* ---- 3.6 COLLISION helpers ---- */

--- a/games/pinata.js
+++ b/games/pinata.js
@@ -179,7 +179,7 @@
       for (let i = 0; i < n; i++) {
         const ang = between(-TAU / 6, TAU / 6);
         const speed = between(200, 350) * (rand(1) < 0.5 ? -1 : 1);
-        this.addSprite({
+        this.queueSpawn({
           type: 'candy',
           e: pick(this.cfg.emojis),
           r: between(20, 32),


### PR DESCRIPTION
## Summary
- introduce a spawn queue in `BaseGame`
- drain queued spawns each frame
- expose `queueSpawn()` helper
- use the new queue in `pinata` candy spawns

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688b6f5f0458832cba91347265b54b4d