### PR TITLE
Improve random selection

### DIFF
--- a/games/fish.js
+++ b/games/fish.js
@@ -16,7 +16,7 @@
 
     spawn(){
       const r = between(...R_RANGE);
-      const swimRight = rand(1) < 0.5;
+      const swimRight = pick([true, false]);
       const speed = between(...V_RANGE);
       const dx = swimRight ? speed : -speed;
       const x = swimRight ? -r : this.W + r;

--- a/games/mole.js
+++ b/games/mole.js
@@ -50,16 +50,10 @@
 
 
     spawn(){
-      let idx = -1;
-      let n = 0;
-      for(let i=0; i<this.holes.length; i++){
-        if(!this.holes[i].occupied){
-          n++;
-          if(rand(n) < 1) idx = i;
-        }
-      }
-      if(idx === -1) return null;
-      const hole = this.holes[idx];
+      const freeHoles = this.holes.filter(h => !h.occupied);
+      if (!freeHoles.length) return null;
+      const hole = pick(freeHoles);
+      const idx = this.holes.indexOf(hole);
       hole.occupied = true;
 
       const d = {

--- a/games/pinata.js
+++ b/games/pinata.js
@@ -178,7 +178,7 @@
       const n = 5 + Math.floor(rand(5));
       for (let i = 0; i < n; i++) {
         const ang = between(-TAU / 6, TAU / 6);
-        const speed = between(200, 350) * (rand(1) < 0.5 ? -1 : 1);
+        const speed = between(200, 350) * pick([-1, 1]);
         this.queueSpawn({
           type: 'candy',
           e: pick(this.cfg.emojis),


### PR DESCRIPTION
## Summary
- simplify random direction in fish game
- use `pick` helper for candy spawn direction
- pick free mole hole using helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b77171970832c949fb0c25d60b1d6