### PR TITLE
Disable text selection on game screen elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,10 +112,14 @@ input[type="range"] {
   border-radius: 12px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
   z-index: 100;
+  -webkit-user-select: none;
+  user-select: none;
 }
 #scoreboard > span {
   --dot: "";
   color: inherit;
+  -webkit-user-select: none;
+  user-select: none;
 }
 #scoreboard > span::before {
   content: var(--dot);
@@ -137,6 +141,8 @@ input[type="range"] {
   margin: 0;
   padding: 0;
   contain: layout style size;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 /* Sprite */
@@ -211,6 +217,8 @@ input[type="range"] {
     0 0 0 0 rgba(0, 162, 255, .4),
     0 0 0 0 rgba(0, 162, 255, .3),
     0 0 0 0 rgba(0, 162, 255, .2);
+  -webkit-user-select: none;
+  user-select: none;
 }
 .ripple.animate { animation: ripple .8s ease-out; }
 


### PR DESCRIPTION
## Summary
- avoid text selection on scoreboard and scores
- disable selection for game layer and ripple effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dab9438c4832c9f690073ba8f64cc