### PR TITLE
refactor: centralize helpers and utilities

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,10 +55,6 @@ function hsvRangeF16(team) {
   return dst;
 }
 
-/* DOM helper with simple caching */
-const domCache = {};
-const $ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
-
 const Config = (() => {
   const DEFAULTS = {
     TOP_W: 640,

--- a/game-engine.js
+++ b/game-engine.js
@@ -4,19 +4,7 @@
 (function (win) {
   'use strict';
 
-  /* DOM helper with simple caching */
-  const domCache = {};
-  const $ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
-
-  const scoreEl = [$('#teamAScore'),$('#teamBScore')];
-
-/* ══════════ 1.  Pure helpers – kept tiny & global ══════════ */
-const R = {
-  rand    : n       => Math.random() * n,
-  pick    : arr     => arr[Math.floor(R.rand(arr.length))],
-  between : (a, b)  => a + R.rand(b - a)
-};
-win.R = R;
+  const scoreEl = [$('#teamAScore'), $('#teamBScore')];
 
 const baseCfg = {
   max: 6,
@@ -87,7 +75,7 @@ class BaseGame {
     this.deadline = 0;
     this._raf = null;
     this._spawnElapsed = 0;
-    this._nextSpawn = R.between(...this.cfg.spawnDelayRange);
+    this._nextSpawn = u.between(...this.cfg.spawnDelayRange);
     this._spawnQueue = [];              // ← NEW  event-driven queue
 
     this.burstEl = document.createElement('div');
@@ -123,7 +111,7 @@ class BaseGame {
       this._spawnElapsed += dt;
       if (this._spawnElapsed >= this._nextSpawn) {
         this._spawnElapsed = 0;
-        this._nextSpawn = R.between(...this.cfg.spawnDelayRange);
+        this._nextSpawn = u.between(...this.cfg.spawnDelayRange);
         const desc = this.spawn();
         if (desc) this.addSprite(desc);
       }
@@ -179,10 +167,10 @@ class BaseGame {
   addSprite(desc) {
     const [rMin, rMax] = this.cfg.rRange;
     const [vMin, vMax] = this.cfg.vRange;
-    desc.r ??= R.between(rMin, rMax);
-    const speed = R.between(vMin, vMax);
-    const ang = R.rand(Math.PI * 2);
-    desc.e ??= R.pick(this.cfg.emojis || []);
+    desc.r ??= u.between(rMin, rMax);
+    const speed = u.between(vMin, vMax);
+    const ang = u.rand(Math.PI * 2);
+    desc.e ??= u.pick(this.cfg.emojis || []);
     desc.dx ??= Math.cos(ang) * speed;
     desc.dy ??= Math.sin(ang) * speed;
 
@@ -199,7 +187,7 @@ class BaseGame {
   }
 
   spawn() {
-    return { x: R.rand(this.W), y: R.rand(this.H) };
+    return { x: u.rand(this.W), y: u.rand(this.H) };
   }
 
   /* ------------------------------------------------------------
@@ -307,9 +295,9 @@ class BaseGame {
     const children = this.burstEl.children;
     for (let i = 0; i < children.length; i++) {
       const p = children[i];
-      p.textContent = R.pick(emojiArr);
-      const sp = 150 + R.rand(150);
-      const vec = R.pick(BURST_VECTORS);
+      p.textContent = u.pick(emojiArr);
+      const sp = 150 + u.rand(150);
+      const vec = u.pick(BURST_VECTORS);
       const dx = vec.x * sp;
       const dy = vec.y * sp;
       p.style.setProperty('--dx', `${dx}px`);

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -1,5 +1,5 @@
 (function(g){
-  const { between, pick, rand } = g.R;
+  const { between, pick, rand } = g.u;
   const TAU = Math.PI * 2;
 
   const BALLOON_SET  = ['🎈'];

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -1,5 +1,5 @@
 (function (g) {
-  const { between, rand, pick } = g.R;
+  const { between, rand, pick } = g.u;
   const TAU = Math.PI * 2;
   const EMOJI_SET = [
     '🕶️','🤖','🥨','🦥','🌻','🪙','🥇','🏆','🎒','','','','🎉','⭐','🥳','💎',

--- a/games/fish.js
+++ b/games/fish.js
@@ -1,5 +1,5 @@
 (function(g){
-  const { rand, between, pick } = g.R;
+  const { rand, between, pick } = g.u;
   const TAU = Math.PI * 2;
   const FISH_SET = ['🐳','🐋','🐬','🦭','🐟','🐠','🦈','🐙','🪼','🦀','🦞','🦐'];
   const FISH_MAX = 6;

--- a/games/fruits.js
+++ b/games/fruits.js
@@ -1,5 +1,5 @@
 (function (g) {
-  const { pick } = g.R;
+  const { pick } = g.u;
   const COLS = 10, ROWS = 5;
   const CELL_COUNT = COLS * ROWS;
   const indexToRow = i => Math.floor(i / COLS);

--- a/games/gem.js
+++ b/games/gem.js
@@ -1,5 +1,5 @@
 (function(g){
-  const { rand, between, pick } = g.R;
+  const { rand, between, pick } = g.u;
   const TAU = Math.PI * 2;
   const EMOJIS = ['💎','🏺','🦴','🪙','💰','🗿','🧭','⏳','🔑','🥣','👞','💍','📿','🔔','📯','🍶','🎖️','🩴','👑','🪉'];
   const BURST  = ['💭'];

--- a/games/mole.js
+++ b/games/mole.js
@@ -1,5 +1,5 @@
 (function(g){
-  const { rand, pick } = g.R;
+  const { rand, pick } = g.u;
   const TAU = Math.PI * 2;
   const MOLE_LIFETIME_SECS = 10;
   const MOLE_MAX = 3;

--- a/games/pinata.js
+++ b/games/pinata.js
@@ -13,7 +13,7 @@
   /* ------------------------------------------------------------
    *  CONSTANTS
    * ---------------------------------------------------------- */
-  const { rand, between, pick } = g.R;
+  const { rand, between, pick } = g.u;
   const TAU = Math.PI * 2;
 
   // Tune‑once gameplay knobs

--- a/index.html
+++ b/index.html
@@ -26,19 +26,20 @@
     <div id="configScreen">
     </div>
   </div>
-  <script src="app.js"></script>
-  <script src="game-engine.js"></script>
-  <script src="games/emoji.js"></script>
-  <script src="games/balloon.js"></script>
-  <script src="games/fish.js"></script>
-  <script src="games/fruits.js"></script>
-  <script src="games/mole.js"></script>
-  <script src="games/gem.js"></script>
-  <script src="games/pinata.js"></script>
-  <script>
-    Game.run('pinata');
-  </script>
-  <script src="screen.js"></script>
+    <script src="screen.js"></script>
+    <script src="app.js"></script>
+    <script src="game-engine.js"></script>
+    <script src="games/emoji.js"></script>
+    <script src="games/balloon.js"></script>
+    <script src="games/fish.js"></script>
+    <script src="games/fruits.js"></script>
+    <script src="games/mole.js"></script>
+    <script src="games/gem.js"></script>
+    <script src="games/pinata.js"></script>
+    <script>
+      Game.run('pinata');
+      initNumberSpinners();
+    </script>
 </body>
 
 </html>

--- a/screen.js
+++ b/screen.js
@@ -1,3 +1,12 @@
+const domCache = {};
+window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
+
+const u = {};
+u.rand = n => Math.random() * n;
+u.pick = arr => arr[Math.floor(u.rand(arr.length))];
+u.between = (a, b) => a + u.rand(b - a);
+window.u = u;
+
 const container = document.getElementById('container');
 
 // Factory to make an observer for a single section
@@ -83,7 +92,7 @@ container.addEventListener('pointercancel', cancelPointer);
 
 
 // Enhance number inputs with spinner buttons
-const initNumberSpinners = () => {
+function initNumberSpinners() {
     document.querySelectorAll('input[type=number]:not([data-spinner])').forEach(input => {
         input.setAttribute('data-spinner', '');
 
@@ -126,6 +135,6 @@ const initNumberSpinners = () => {
         input.addEventListener('input', update);
         update();
     });
-};
+}
 
-initNumberSpinners();
+window.initNumberSpinners = initNumberSpinners;


### PR DESCRIPTION
## Summary
- Load `screen.js` before other scripts and expose global helpers for DOM caching and utilities.
- Switch game engine and mini-games to the new `u` namespace and move number-spinner init into `index.html`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e572370b0832cbd54662285373d4d