### PR TITLE
Refactor screen.js for vertical pager

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -1,95 +1,60 @@
+/*───────────────────────────────────────────────────────────
+    Globals
+───────────────────────────────────────────────────────────*/
 const domCache = {};
 window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
 
-const u = {};
-u.rand = n => Math.random() * n;
-u.pick = arr => arr[Math.floor(u.rand(arr.length))];
-u.between = (a, b) => a + u.rand(b - a);
-window.u = u;
+window.u = Object.freeze({
+  rand   : n      => Math.random() * n,
+  pick   : arr    => Math.floor(Math.random() * arr.length),
+  between: (a, b) => a + Math.random() * (b - a),
+  clamp  : (n,l,h)=> n < l ? l : n > h ? h : n
+});
 
 const container = document.getElementById('container');
 
-// Factory to make an observer for a single section
-const createSectionObserver = (onEnter, onLeave) =>
-    new IntersectionObserver(entries => {
-        for (const entry of entries) {
-            if (entry.intersectionRatio === 1) onEnter();
-            else if (entry.intersectionRatio === 0) onLeave();
-        }
-    }, { root: container, threshold: [0.1, 1] });
+/*───────────────────────────────────────────────────────────
+    Three-page vertical pager  (0-launcher | 1-game | 2-config)
+───────────────────────────────────────────────────────────*/
+const PAGE_H  = () => container.clientHeight;
+const MAX_IDX = 2;
+let   index   = 0;
 
-// Section 1
-const sec1 = document.getElementById('gameScreen');
-createSectionObserver(
-    () => { console.log('Enter gameScreen'); /* start 1 */ },
-    () => { console.log('Leave gameScreen'); /* stop 1 */ }
-).observe(sec1);
-// === custom swipe handling ===
-const THRESHOLD = 30;
-let startX = 0;
-let startY = 0;
-let startTarget = null;
-let pointerDown = false;
+function snapTo(i) {
+  index = Math.max(0, Math.min(i, MAX_IDX));
+  container.scrollTo({ top: index * PAGE_H(), behavior: 'smooth' });
+}
 
-const onSwipeLeft = () => {
-    console.log('Swiped LEFT!');
-    Game.run(Game.current + 1);
-};
-const onSwipeRight = () => {
-    console.log('Swiped RIGHT!');
-    Game.run(Game.current - 1);
-};
+/* global vertical swipe */
+let startY = null;
 
-const scrollToIndex = idx => {
-    const top = idx * container.clientHeight;
-    container.scrollTo({ top, behavior: 'smooth' });
-};
-const currentIndex = () => Math.round(container.scrollTop / container.clientHeight);
-const scrollNext = () => {
-    const max = container.childElementCount - 1;
-    const i = currentIndex();
-    if (i < max) scrollToIndex(i + 1);
-};
-const scrollPrev = () => {
-    const i = currentIndex();
-    if (i > 0) scrollToIndex(i - 1);
-};
-
-const handleSwipe = (dx, dy, target) => {
-    const absX = Math.abs(dx);
-    const absY = Math.abs(dy);
-    if (absY > absX && absY > THRESHOLD) {
-        dy < 0 ? scrollNext() : scrollPrev();
-    } else if (absX > absY && absX > THRESHOLD) {
-        if (target.closest('#gameScreen')) {
-            dx < 0 ? onSwipeLeft() : onSwipeRight();
-        }
-    }
-};
-
-// Pointer events unify mouse and touch interactions
 container.addEventListener('pointerdown', e => {
-    if (!e.isPrimary) return;
-    pointerDown = true;
-    startX = e.clientX;
-    startY = e.clientY;
-    startTarget = e.target;
-    if (e.pointerType === 'mouse') e.preventDefault();
-});
+  if (!e.isPrimary) return;
+  startY = e.clientY;
+  container.setPointerCapture(e.pointerId);   // guarantees pointerup
+}, { passive: true });
 
 container.addEventListener('pointerup', e => {
-    if (!pointerDown || !e.isPrimary) return;
-    pointerDown = false;
-    const dx = e.clientX - startX;
-    const dy = e.clientY - startY;
-    handleSwipe(dx, dy, startTarget);
+  if (startY == null) return;
+  const dy = e.clientY - startY;
+  startY = null;
+  if (Math.abs(dy) < 50) return;              // ignore micro swipes
+  snapTo(index + (dy > 0 ? -1 : 1));          // down→prev, up→next
 });
 
-// Cancel a drag if the pointer leaves or is cancelled
-const cancelPointer = () => { pointerDown = false; };
-container.addEventListener('pointerleave', cancelPointer);
-container.addEventListener('pointercancel', cancelPointer);
+/*───────────────────────────────────────────────────────────
+    Launcher page buttons  (page-0 only)
+───────────────────────────────────────────────────────────*/
+const launcher = $('#launcher');
 
+if (launcher) {
+  launcher.addEventListener('click', e => {
+    const btn = e.target.closest('[data-game]');
+    if (!btn) return;
+  // game.run selected game 
+    snapTo(1);                                // jump to game page
+  });
+}
 
 // Enhance number inputs with spinner buttons
 function initNumberSpinners() {
@@ -138,3 +103,4 @@ function initNumberSpinners() {
 }
 
 window.initNumberSpinners = initNumberSpinners;
+


### PR DESCRIPTION
## Summary
- replace legacy section observers and swipe logic with three-page vertical pager and pointer-based swipe handling
- expose global utility helpers including new `clamp`
- add launcher button handler to switch to game page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e725df8e4832ca32ec18f61be5594