### PR TITLE
Add launcher screen for selecting games and config

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -361,8 +361,12 @@ class BaseGame {
 }
 
 /* ══════════ 4. helper : turn plain config into subclass ══════════ */
-BaseGame.make = cfg => class Game extends BaseGame {
-  constructor() { super(cfg); Object.assign(this, cfg); }
+BaseGame.make = cfg => {
+  class Game extends BaseGame {
+    constructor() { super(cfg); Object.assign(this, cfg); }
+  }
+  Game.icon = cfg.icon;
+  return Game;
 };
 
 /* ══════════ 5. registry + public runner ══════════ */
@@ -421,6 +425,14 @@ function cleanupLayer() {
 Game.register = (id, cls) => {
   cls.prototype.gameName = id;
   REG.push({ id, cls });
+  const launcher = document.getElementById('launcher');
+  if (launcher && cls.icon) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = cls.icon;
+    btn.dataset.game = id;
+    launcher.prepend(btn);
+  }
 };
 
 Object.defineProperty(Game, 'current', { get: () => idx });

--- a/games/balloon.js
+++ b/games/balloon.js
@@ -14,6 +14,7 @@
   const SAT_RANGE    = [0.9, 1.0];
 
   g.Game.register('balloon', g.BaseGame.make({
+    icon: BALLOON_SET[0],
     max: BALLOON_MAX,
     emojis: BALLOON_SET,
     spawnDelayRange: SPAWN_DELAY_RANGE,

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -18,6 +18,7 @@
   const ROT_FREQ = 0.03;
 
   g.Game.register('emoji', g.BaseGame.make({
+    icon       : EMOJI_SET[0],
     max        : EMOJI_MAX,
     emojis     : EMOJI_SET,
     spawnDelayRange : SPAWN_DELAY_RANGE,

--- a/games/fish.js
+++ b/games/fish.js
@@ -8,6 +8,7 @@
   const V_RANGE = [10, 180];
 
   g.Game.register('fish', g.BaseGame.make({
+    icon: FISH_SET[0],
     max: FISH_MAX,
     emojis: FISH_SET,
     burst: ['🫧'],

--- a/games/fruits.js
+++ b/games/fruits.js
@@ -20,6 +20,7 @@
   }
 
   g.Game.register('fruits', g.BaseGame.make({
+    icon   : FRUITS[0],
     max    : CELL_COUNT,
     emojis : FRUITS,
     spawnDelayRange : [0, 0],

--- a/games/gem.js
+++ b/games/gem.js
@@ -8,6 +8,7 @@
   const EMOJI_MAX = 6;
 
   g.Game.register('gem', g.BaseGame.make({
+    icon           : EMOJIS[0],
     max            : EMOJI_MAX,
     emojis         : EMOJIS,
     spawnDelayRange: [0, 1],

--- a/games/mole.js
+++ b/games/mole.js
@@ -39,6 +39,7 @@
   }
 
   g.Game.register('mole', g.BaseGame.make({
+    icon: MOLE_EMOJIS[0],
     max: MOLE_MAX,
     emojis: MOLE_EMOJIS,
     burst: ['💫'],

--- a/games/pinata.js
+++ b/games/pinata.js
@@ -66,6 +66,7 @@
    *  Game definition
    * ---------------------------------------------------------- */
   g.Game.register('pinata', g.BaseGame.make({
+    icon: '🪅',
     max: 0,            // disable auto‑spawn from engine
     collisions: false, // no sprite–sprite collisions
     emojis: ['🍬', '🍭', '🍡', '🍫', '🍪', '🧁'],

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 
 <body>
   <div id="container">
+    <div id="launcher">
+      <button type="button" data-config>⚙️</button>
+    </div>
     <div id="gameScreen">
       <div id="scoreboard">
         <span id="teamAScore">0</span>
@@ -37,7 +40,6 @@
     <script src="games/gem.js"></script>
     <script src="games/pinata.js"></script>
     <script>
-      Game.run('pinata');
       initNumberSpinners();
     </script>
 </body>

--- a/screen.js
+++ b/screen.js
@@ -49,10 +49,15 @@ const launcher = $('#launcher');
 
 if (launcher) {
   launcher.addEventListener('click', e => {
-    const btn = e.target.closest('[data-game]');
+    const btn = e.target.closest('button');
     if (!btn) return;
-  // game.run selected game 
-    snapTo(1);                                // jump to game page
+    const game = btn.dataset.game;
+    if (game) {
+      Game.run(game);
+      snapTo(1); // jump to game page
+    } else if (btn.dataset.config !== undefined) {
+      snapTo(2); // jump to config page
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -30,6 +30,22 @@ body {
   overflow: hidden;
 }
 
+#launcher {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  font-size: 4rem;
+}
+
+#launcher button {
+  background: none;
+  border: none;
+  font: inherit;
+  cursor: pointer;
+}
+
 /* Config screen grid */
 #configScreen {
   display: grid;


### PR DESCRIPTION
## Summary
- Use per-game icons when registering games for launcher buttons
- Prepend game buttons so the settings button stays at the end of the launcher
- Remove default icon logic from base game helper
- Set launcher icons via game config instead of separate assignments
- Register each game inline with its icon configuration, avoiding extra constants

## Testing
- `node --check game-engine.js games/balloon.js games/emoji.js games/fish.js games/fruits.js games/gem.js games/mole.js games/pinata.js screen.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7488ef84832ca399f5493935c289