### PR TITLE
Fix emoji picker to show proper images

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -6,7 +6,7 @@ window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel))
 
 window.u = Object.freeze({
   rand   : n      => Math.random() * n,
-  pick   : arr    => Math.floor(Math.random() * arr.length),
+  pick   : arr    => arr[Math.floor(Math.random() * arr.length)],
   between: (a, b) => a + Math.random() * (b - a),
   clamp  : (n,l,h)=> n < l ? l : n > h ? h : n
 });


### PR DESCRIPTION
## Summary
- Correct `u.pick` to return a random emoji instead of an array index so spawned emojis display correctly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eeda405b8832c96b82d0e92adcf7f