### PR TITLE
refactor: modernize launcher hit handling

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -456,7 +456,7 @@ Game.routeHit = (x, y, team) => {
     case 0: {                            /* launcher page */
       const btn = document.elementFromPoint(x, y)
                  ?.closest('#launcher button[data-game]');
-      if (btn && btn.dataset.game) {
+      if (btn?.dataset.game) {
         Game.run(btn.dataset.game);
         if (typeof snapTo === 'function') snapTo(1);  /* scroll to game */
       }


### PR DESCRIPTION
## Summary
- refactor launcher hit routing to use optional chaining

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4dde7108832c9ac94fbb6d21b62e