### PR TITLE
Different miss animation and team-colored ripples

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -289,7 +289,7 @@ class BaseGame {
   /* ---- 3.7b MISS entry point ---- */
   miss(s) {
     if (typeof this.onMiss === 'function') this.onMiss(s);
-    this._popSprite(s);
+    this._missSprite(s);
   }
 
   /* ---- 3.8 POP animation ---- */
@@ -299,6 +299,14 @@ class BaseGame {
     s.style.setProperty('--x', `${s.x - s.r}px`);
     s.style.setProperty('--y', `${s.y - s.r}px`);
     s.el.classList.add('pop');
+  }
+
+  _missSprite(s) {               // visual + remove() with different animation
+    s.alive = false;
+    s.el.classList.remove('spawn');
+    s.style.setProperty('--x', `${s.x - s.r}px`);
+    s.style.setProperty('--y', `${s.y - s.r}px`);
+    s.el.classList.add('miss');
   }
 
   emitBurst(x, y, emojiArr = this.cfg.burst) {
@@ -331,8 +339,12 @@ class BaseGame {
     el.addEventListener('animationend', () => el.remove(), { once: true });
   }
 
-  _showRipple(x, y) {
+  _showRipple(x, y, team) {
     Object.assign(this.ripple.style, { left: `${x}px`, top: `${y}px` });
+    this.ripple.className = 'ripple';
+    if (team === 0 || team === 1) {
+      this.ripple.classList.add(Game.teams[team]);
+    }
     this.ripple.classList.remove('animate');
     void this.ripple.offsetWidth;
     this.ripple.classList.add('animate');
@@ -340,7 +352,7 @@ class BaseGame {
 
   /* ---- handle hits triggered by pointer events or via Game.doHit ---- */
   doHit = (x, y, team) => {
-    this._showRipple(x, y);
+    this._showRipple(x, y, team);
     for (const s of this.sprites) {
       if ((x - s.x) ** 2 + (y - s.y) ** 2 <= s.r ** 2) {
         this.hit(s, team);
@@ -364,7 +376,7 @@ class BaseGame {
           this.onSpriteAlive(sp);
         }
       }
-    } else if (el.classList.contains('pop')) {
+    } else if (el.classList.contains('pop') || el.classList.contains('miss')) {
       sp.remove();
     }
   };

--- a/style.css
+++ b/style.css
@@ -240,11 +240,13 @@ input {
 
 .sprite.spawn { animation: spawn 0.3s ease-out; }
 .sprite.pop   { animation: pop 0.2s ease-out forwards; }
+.sprite.miss  { animation: miss 0.4s ease-out forwards; }
 @keyframes spawn {
   from { transform: translate3d(var(--x), var(--y), 0) scale(0); opacity: 0; }
   to   { transform: translate3d(var(--x), var(--y), 0) scale(1); opacity: 1; }
 }
 @keyframes pop { to { transform: scale(0); opacity: 0; } }
+@keyframes miss { to { transform: translate3d(var(--x), var(--y), 0) scale(1.5); opacity: 0; } }
 
 /* Burst */
 .burst {
@@ -319,8 +321,16 @@ input {
     0 0 0 0 rgba(0, 162, 255, .2);
   -webkit-user-select: none;
   user-select: none;
+  filter: hue-rotate(var(--hue, var(--hue-blue)));
 }
 .ripple.animate { animation: ripple .8s ease-out; }
+
+.ripple.red    { --hue: var(--hue-red); }
+.ripple.orange { --hue: var(--hue-orange); }
+.ripple.yellow { --hue: var(--hue-yellow); }
+.ripple.green  { --hue: var(--hue-green); }
+.ripple.blue   { --hue: var(--hue-blue); }
+.ripple.purple { --hue: var(--hue-purple); }
 
 @keyframes ripple {
   0% {


### PR DESCRIPTION
## Summary
- Add distinct miss animation and use pop only on hits
- Color ripple effect according to hitting team

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894398de27c832c937b756772fcafed