### PR TITLE
Apply saved zoom at initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -543,7 +543,6 @@ const Feeds = (() => {
 
     videoFront.srcObject = frontStream;
     track = frontStream.getVideoTracks()[0];
-    await videoFront.play();
 
     const cap = track.getCapabilities();
     const adv = {};
@@ -556,7 +555,10 @@ const Feeds = (() => {
       zoomInput.min = min;
       zoomInput.max = Math.min(2, max);
       zoomInput.step = step || 0.1;
+      const storedZoom = localStorage.getItem('zoom');
+      if (storedZoom !== null) cfg.zoom = JSON.parse(storedZoom);
       zoomInput.value = cfg.zoom;
+      adv.zoom = cfg.zoom;
       zoomInput.addEventListener('input', async () => {
         adv.zoom = parseFloat(zoomInput.value);
         cfg.zoom = adv.zoom;
@@ -570,8 +572,14 @@ const Feeds = (() => {
     }
 
     if (Object.keys(adv).length) {
-      await track.applyConstraints({ advanced: [adv] });
+      try {
+        await track.applyConstraints({ advanced: [adv] });
+      } catch (err) {
+        console.error('Zoom apply failed:', err);
+      }
     }
+
+    await videoFront.play();
   }
 
   return {


### PR DESCRIPTION
## Summary
- retrieve zoom level from local storage and apply it before video playback so camera starts with saved zoom

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6894789acfe0832c87752dc8bcedc7b4