### PR TITLE
chore: set module type for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /game - Copy.js
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "web-ball-game",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"No tests\"",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "bonjour": "^3.5.0",
+    "ws": "^8.18.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with `type: module` and dependencies
- ignore node_modules in git
- point package main entry to `server.js`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bonjour)*
- `npm test`
- `npm start` *(fails: Cannot find package 'ws')*


------
https://chatgpt.com/codex/tasks/task_e_6894dd7a4e40832cbf96588baf1816ff