### PR TITLE
Serve static files from repository root

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ import { WebSocketServer } from 'ws';
 import bonjour from 'bonjour';
 
 const PORT       = 8000;            // HTTP + WS same port
-const PUBLIC_DIR = 'public';        // put client.html here
+const PUBLIC_DIR = '.';             // serve files from repo root
 const MIME = {                       // very small mime table
   '.html':'text/html',
   '.js'  :'application/javascript',
@@ -18,7 +18,7 @@ const MIME = {                       // very small mime table
 
 // ---------- tiny static-file web server ----------
 const server = createServer(async (req, res) => {
-  let file = req.url === '/' ? '/index.html' : req.url;
+  const file = req.url === '/' ? 'index.html' : req.url.slice(1);
   try {
     const data = await readFile(join(PUBLIC_DIR, file));
     res.writeHead(200, {'Content-Type': MIME[extname(file)] || 'application/octet-stream'});


### PR DESCRIPTION
## Summary
- update server.js to look for static files in the repository root
- support serving top.html directly via `http://localhost:8000/top.html`

## Testing
- `npm test`
- `node server.js &` then `curl -i http://localhost:8000/top.html`

------
https://chatgpt.com/codex/tasks/task_e_6895b16b4b20832cb8544178d3b65c4e