### PR TITLE
Use localhost for top page websocket

### DIFF
--- a/rtc-connect.js
+++ b/rtc-connect.js
@@ -1,5 +1,11 @@
-// ---- 1. connect to signalling server on same host ----
-const ws = new WebSocket('ws://p2p.local:8000');
+// ---- 1. connect to signalling server ----
+// default to p2p.local, but use localhost when top.html is served locally
+let wsHost = 'p2p.local:8000';
+if (window.location.hostname === 'localhost' &&
+    window.location.pathname.endsWith('top.html')) {
+  wsHost = window.location.host;
+}
+const ws = new WebSocket('ws://' + wsHost);
 ws.onopen = () => window.handleLog && handleLog('Waiting for peer…');
 ws.onmessage = async e => {
   // if we accidentally got a binary frame, it'll arrive as a Blob


### PR DESCRIPTION
## Summary
- default websocket host to p2p.local
- use localhost host when top.html is loaded from localhost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895b50282a4832c960324c2da88e47d