### PR TITLE
Swap top camera video dimensions

### DIFF
--- a/rtc-top.js
+++ b/rtc-top.js
@@ -257,14 +257,16 @@
       videoTop = $('#topVid');
       const stream = await navigator.mediaDevices.getUserMedia({
         audio:false,
-        video:{ width:{ ideal: cfg.TOP_W }, height:{ ideal: cfg.TOP_H },
+        // Request landscape video, keeping canvas values portrait.
+        video:{ width:{ ideal: cfg.TOP_H }, height:{ ideal: cfg.TOP_W },
                 facingMode:'user', frameRate:{ideal:60,max:120} }
       });
       videoTop.srcObject = stream;
       await videoTop.play();
       /* ---- after play(): update cfg + UI with the real resolution ---- */
-      cfg.TOP_W = videoTop.videoWidth;
-      cfg.TOP_H = videoTop.videoHeight;
+      // Swap the reported dimensions so cfg stays portrait (width < height)
+      cfg.TOP_W = videoTop.videoHeight;
+      cfg.TOP_H = videoTop.videoWidth;
       Config.save('TOP_W', cfg.TOP_W);
       Config.save('TOP_H', cfg.TOP_H);
 


### PR DESCRIPTION
## Summary
- Request top camera stream with landscape 640x480 resolution while keeping portrait canvas
- Preserve portrait dimensions by swapping reported video width and height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689602702874832c97be90a13920708b