### PR TITLE
Round HSV thresholds when saving and displaying

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,7 +274,8 @@ const Setup = (() => {
       inp.addEventListener('input', e => {
         const base = TEAM_INDICES[cfg.teamA] * 6 + i;
         COLOR_TABLE[base] = parseFloat(e.target.value);
-        localStorage.setItem('COLOR_TABLE', JSON.stringify(Array.from(COLOR_TABLE)));
+        localStorage.setItem('COLOR_TABLE',
+          JSON.stringify(Array.from(COLOR_TABLE, v => +v.toFixed(2))));
         cfg.f16Ranges[cfg.teamA] = hsvRangeF16(cfg.teamA);
       });
     }
@@ -287,7 +288,7 @@ const Setup = (() => {
     initNumberSpinners();
     function updateThreshInputs() {
       const base = TEAM_INDICES[cfg.teamA] * 6;
-      for (let i = 0; i < 6; i++) thInputs[i].value = COLOR_TABLE[base + i];
+      for (let i = 0; i < 6; i++) thInputs[i].value = (+COLOR_TABLE[base + i].toFixed(2));
     }
     const topOv = $('#topOv');
     const frontOv = $('#frontOv');

--- a/rtc-top.js
+++ b/rtc-top.js
@@ -214,13 +214,14 @@
         inp.addEventListener('input', e => {
           const base = TEAM_INDICES[cfg.teamA] * 6 + i;
           COLOR_TABLE[base] = parseFloat(e.target.value);
-          localStorage.setItem('COLOR_TABLE', JSON.stringify(Array.from(COLOR_TABLE)));
+          localStorage.setItem('COLOR_TABLE',
+            JSON.stringify(Array.from(COLOR_TABLE, v => +v.toFixed(2))));
           cfg.f16Ranges[cfg.teamA] = hsvRangeF16(cfg.teamA);
         });
       }
       function updateThreshInputs(){
         const base = TEAM_INDICES[cfg.teamA] * 6;
-        for (let i = 0; i < 6; i++) thInputs[i].value = COLOR_TABLE[base + i];
+        for (let i = 0; i < 6; i++) thInputs[i].value = (+COLOR_TABLE[base + i].toFixed(2));
       }
       updateThreshInputs();
 


### PR DESCRIPTION
## Summary
- Round HSV threshold values to two decimals when persisting to localStorage.
- Display stored HSV values rounded to two decimals, preventing float precision artifacts.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e12c12c832cb6ba9e7bea1b6bc1