### PR TITLE
refactor: switch Netlify functions to default exports

### DIFF
--- a/netlify/functions/signal-reset.mts
+++ b/netlify/functions/signal-reset.mts
@@ -1,18 +1,10 @@
 import { getStore } from '@netlify/blobs'
-import type { Handler } from '@netlify/functions'
+import type { Context } from '@netlify/functions'
 
-export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' }
-  }
+export default async (req: Request, _context: Context) => {
+  if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 })
   const store = getStore({ name: 'webrtc', consistency: 'strong' })
   const list = await store.list({ prefix: 'room/default/' })
-  for (const { key } of list.blobs) {
-    await store.delete(key)
-  }
-  return {
-    statusCode: 200,
-    headers: { 'content-type': 'text/plain', 'cache-control': 'no-store' },
-    body: 'OK',
-  }
+  for (const { key } of list.blobs) await store.delete(key)
+  return new Response('OK', { headers: { 'content-type': 'text/plain', 'cache-control': 'no-store' } })
 }


### PR DESCRIPTION
## Summary
- use default exported async functions for Netlify blobs API
- migrate signal functions to Request/Response interface for v2

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'node:http', etc.)*
- `npm install --no-save @types/node` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68984ba68e78832c8c4c138e0544e14c