### PR TITLE
refactor: move rtc logic to shared script

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,53 +31,22 @@
     </div>
   </div>
     <script src="screen.js"></script>
+    <script src="webrtc-ab.js"></script>
     <script>
-const F = '/.netlify/functions';
 let dc;
 const stateEl = document.getElementById('state');
-function handleLog(msg){ stateEl.textContent = msg; }
-async function write(kind, role, data){
-  const rW = await fetch(`${F}/signal-write?_=${Date.now()}`, {
-    method:'POST', headers:{'content-type':'application/json'},
-    body: JSON.stringify({ kind, role, data })
-  });
-  if(!rW.ok) handleLog('write failed '+rW.status);
-}
-async function poll(role){
-  const r = await fetch(`${F}/signal-read?role=${role}&_=${Date.now()}`, { cache:'no-store' });
-  if(!r.ok){ handleLog('read failed '+r.status); return { offer:null, answer:null, candidates:[] }; }
-  return r.json();
-}
-async function startB(){
-  const pc = new RTCPeerConnection({ iceServers:[{urls:'stun:stun.l.google.com:19302'}] });
-  pc.oniceconnectionstatechange = ()=> handleLog('ice: '+pc.iceConnectionState);
-  pc.onicecandidate = e=>{ if(e.candidate) write('candidate','b', e.candidate); };
-  pc.ondatachannel = e=>{
+function log(msg){ stateEl.textContent = msg; }
+StartB().then(ctrl => {
+  const pc = ctrl.pc;
+  if(!pc){ log('no offer found — open A first'); return; }
+  pc.ondatachannel = e => {
     dc = e.channel;
-    dc.onopen = ()=>{ handleLog('connected'); window.handleOpen && handleOpen(); };
-    dc.onmessage = m=> console.log('msg:', m.data);
+    log('connected');
+    dc.onmessage = ev => console.log('msg:', ev.data);
+    if(window.handleOpen) handleOpen();
   };
-  const t = setInterval(async ()=>{
-    const { offer, candidates } = await poll('b');
-    if(offer && !pc.currentRemoteDescription){
-      await pc.setRemoteDescription(offer);
-      handleLog('got offer');
-      const answer = await pc.createAnswer();
-      await pc.setLocalDescription(answer);
-      await write('answer','b', answer);
-      handleLog('sent answer');
-    }
-    for(const c of candidates||[]){
-      await pc.addIceCandidate(c);
-    }
-    if(pc.iceConnectionState==='connected'||pc.iceConnectionState==='completed'){
-      clearInterval(t);
-      handleLog('connected');
-    }
-  },800);
-}
-startB().catch(err=>handleLog('ERR: '+(err&&(err.stack||err))));
-function sendBit(bit){ if(dc&&dc.readyState==='open') dc.send(bit); }
+}).catch(err => log('ERR: '+(err && (err.stack || err))));
+function sendBit(bit){ if(dc && dc.readyState === 'open') dc.send(bit); }
 window.sendBit = sendBit;
     </script>
     <script src="app.js"></script>

--- a/top.html
+++ b/top.html
@@ -37,62 +37,20 @@
       $('#b1').onclick = () => sendBit('1');
     }
   </script>
+  <script src="webrtc-ab.js"></script>
   <script>
-const F = '/.netlify/functions';
 let dc;
-async function reset(){
-  const r0 = await fetch(`${F}/signal-reset?_=${Date.now()}`, { method:'POST', cache:'no-store' });
-  if(!r0.ok){ handleLog('reset failed '+r0.status); throw new Error('reset failed'); }
-  handleLog('room: reset done');
-}
-async function write(kind, role, data){
-  const rW = await fetch(`${F}/signal-write?_=${Date.now()}`, {
-    method:'POST', headers:{'content-type':'application/json'},
-    body: JSON.stringify({ kind, role, data })
-  });
-  if(!rW.ok) handleLog('write failed '+rW.status);
-}
-async function poll(role){
-  const r = await fetch(`${F}/signal-read?role=${role}&_=${Date.now()}`, { cache:'no-store' });
-  if(!r.ok){ handleLog('read failed '+r.status); return { offer:null, answer:null, candidates:[] }; }
-  return r.json();
-}
-async function startA(){
-  const pc = new RTCPeerConnection({ iceServers:[{urls:'stun:stun.l.google.com:19302'}] });
-  const channel = pc.createDataChannel('chat');
-  dc = channel;
-  channel.onopen = ()=>{ handleLog('dc: open'); channel.send('hello from A'); window.handleOpen && handleOpen(); };
-  channel.onmessage = e=> console.log('msg:', e.data);
-  pc.oniceconnectionstatechange = ()=> handleLog('ice: '+pc.iceConnectionState);
-  pc.onicecandidate = e=>{ if(e.candidate) write('candidate','a', e.candidate); };
-  const offer = await pc.createOffer();
-  await pc.setLocalDescription(offer);
-  await write('offer','a', offer);
-  handleLog('sent offer');
-  const t = setInterval(async ()=>{
-    const { answer, candidates } = await poll('a');
-    if(answer && !pc.currentRemoteDescription){
-      await pc.setRemoteDescription(answer);
-      handleLog('got answer');
-    }
-    for(const c of candidates||[]){
-      await pc.addIceCandidate(c);
-    }
-    if(pc.iceConnectionState==='connected'||pc.iceConnectionState==='completed'){
-      clearInterval(t);
-      handleLog('connected');
-    }
-  },800);
-}
-(async function main(){
-  try {
-    await reset();
-    await startA();
-  } catch(err){
-    handleLog('ERR: '+(err&&(err.stack||err)));
-  }
-})();
-function sendBit(bit){ if(dc&&dc.readyState==='open') dc.send(bit); }
+StartA().then(ctrl => {
+  dc = ctrl.channel;
+  if(!dc){ handleLog('No data channel'); return; }
+  dc.onopen = () => {
+    handleLog('dc: open');
+    dc.send('hello from A');
+    handleOpen();
+  };
+  dc.onmessage = (e) => console.log('msg:', e.data);
+}).catch(err => handleLog('ERR: '+(err && (err.stack || err))));
+function sendBit(bit){ if(dc && dc.readyState === 'open') dc.send(bit); }
 window.sendBit = sendBit;
   </script>
   <script src="rtc-top.js"></script>

--- a/webrtc-ab.js
+++ b/webrtc-ab.js
@@ -1,0 +1,165 @@
+/*!
+  Minimal WebRTC A/B helper for Netlify Blobs signaling (single room).
+  Usage in each HTML:
+    <script src="webrtc-ab.js"></script>
+    <script>
+      // A (top.html)
+      StartA();
+      // B (index.html)
+      StartB();
+    </script>
+*/
+(() => {
+  const DEFAULTS = {
+    base: '/.netlify/functions',
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    timeoutMs: 120000, // 2 minutes
+    backoff: [400, 800, 1500, 3000, 5000],
+    log: (...args) => console.log(...args),
+    onOpen: () => {},
+    onMessage: () => {},
+    onState: () => {}
+  };
+
+  // -------- HTTP helpers (no-store + cache buster) --------
+  const j = (o)=>JSON.stringify(o);
+  const qs = () => `_=${Date.now()}`;
+  async function post(base, name, body) {
+    const r = await fetch(`${base}/${name}?${qs()}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      cache: 'no-store',
+      body: j(body)
+    });
+    return r;
+  }
+  async function get(base, name, params) {
+    const u = new URL(`${base}/${name}`, location.href);
+    Object.entries(params || {}).forEach(([k,v]) => u.searchParams.set(k, v));
+    u.searchParams.set('_', Date.now().toString());
+    const r = await fetch(u.toString(), { cache: 'no-store' });
+    return r.ok ? r.json() : Promise.reject(new Error(`GET ${name} ${r.status}`));
+  }
+
+  // -------- Signaling wrappers --------
+  const resetRoom = (base) => post(base, 'signal-reset', {});
+  const write = (base, kind, role, data) => post(base, 'signal-write', { kind, role, data });
+  const readA = (base) => get(base, 'signal-read', { role: 'a' });
+  const readB = (base) => get(base, 'signal-read', { role: 'b' });
+
+  // -------- WebRTC helpers --------
+  const waitIceComplete = (pc) => new Promise((res) => {
+    if (pc.iceGatheringState === 'complete') return res();
+    pc.addEventListener('icegatheringstatechange', () => {
+      if (pc.iceGatheringState === 'complete') res();
+    });
+  });
+  const until = (ms) => new Promise(r => setTimeout(r, ms));
+
+  function wirePc(pc, opts, channelMaybe) {
+    const { log, onState } = opts;
+    pc.addEventListener('iceconnectionstatechange', () => log('ice:', pc.iceConnectionState));
+    pc.addEventListener('connectionstatechange', () => {
+      log('pc.connectionState:', pc.connectionState);
+      onState(pc.connectionState);
+    });
+    if (channelMaybe) {
+      const { onOpen, onMessage } = opts;
+      channelMaybe.onopen = () => onOpen(channelMaybe, pc);
+      channelMaybe.onmessage = (e) => onMessage(String(e.data), channelMaybe, pc);
+    } else {
+      pc.ondatachannel = (e) => {
+        const ch = e.channel;
+        const { onOpen, onMessage } = opts;
+        ch.onopen = () => onOpen(ch, pc);
+        ch.onmessage = (ev) => onMessage(String(ev.data), ch, pc);
+      };
+    }
+  }
+
+  function makeController(pc, ch, log) {
+    return {
+      pc,
+      channel: ch || null,
+      send: (msg) => ch && ch.readyState === 'open' ? ch.send(msg) : false,
+      stop: () => { try { ch && ch.close(); } catch{} try { pc.close(); } catch{} log('stopped'); }
+    };
+  }
+
+  // -------- Public APIs --------
+
+  // Peer A: reset room, batch-ICE offer, poll ONLY for answer (backoff + timeout)
+  window.StartA = async function StartA(userOpts = {}) {
+    const opts = { ...DEFAULTS, ...userOpts };
+    const { base, iceServers, timeoutMs, backoff, log } = opts;
+
+    // 1) Reset room
+    const r = await resetRoom(base);
+    if (!r.ok) { log('reset failed', r.status); throw new Error('reset failed'); }
+    log('room: reset done');
+
+    // 2) Create PC and DataChannel
+    const pc = new RTCPeerConnection({ iceServers });
+    const ch = pc.createDataChannel('chat');
+    wirePc(pc, opts, ch);
+
+    // 3) Batch ICE: send offer after gathering completes
+    await pc.setLocalDescription(await pc.createOffer());
+    await waitIceComplete(pc);
+    await write(base, 'offer', 'a', pc.localDescription);
+    log('sent: offer (batched ICE)');
+
+    // 4) Poll only for ANSWER with adaptive backoff + timeout
+    const t0 = Date.now();
+    let i = 0;
+    while (true) {
+      if (Date.now() - t0 > timeoutMs) { log('timeout: no answer — stopping'); break; }
+      const { answer } = await readA(base).catch(e => { log('readA error', e.message); return {}; });
+      if (answer && !pc.currentRemoteDescription) {
+        await pc.setRemoteDescription(answer);
+        log('got: answer (Peer B joined)');
+        break;
+      }
+      await until(backoff[i]); i = Math.min(i + 1, backoff.length - 1);
+    }
+
+    return makeController(pc, ch, log);
+  };
+
+  // Peer B: single check for offer; if absent => quit. If present => batch-ICE answer.
+  window.StartB = async function StartB(userOpts = {}) {
+    const opts = { ...DEFAULTS, ...userOpts };
+    const { base, iceServers, timeoutMs, log } = opts;
+
+    // 1) Single check — is A present? (offer exists)
+    const first = await readB(base).catch(e => { log('readB error', e.message); return {}; });
+    if (!first || !first.offer) {
+      log('no offer found — open A (top.html) first'); // quit early
+      return { status: 'no-offer', pc: null, channel: null, send: () => false, stop: () => {} };
+    }
+
+    // 2) Create PC only if offer exists
+    const pc = new RTCPeerConnection({ iceServers });
+    wirePc(pc, opts, null);
+
+    // 3) Set remote offer, create batched answer
+    await pc.setRemoteDescription(first.offer);
+    log('got: offer');
+    await pc.setLocalDescription(await pc.createAnswer());
+    await waitIceComplete(pc);
+    await write(base, 'answer', 'b', pc.localDescription);
+    log('sent: answer (batched ICE)');
+
+    // 4) Optional: timeout watcher for connection establishment
+    const t0 = Date.now();
+    (async function watch() {
+      if (!pc) return;
+      if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') return;
+      if (Date.now() - t0 > timeoutMs) { log('timeout: connection not established'); return; }
+      await until(1000); watch();
+    })();
+
+    return makeController(pc, null, log);
+  };
+})();
+


### PR DESCRIPTION
## Summary
- centralize WebRTC signaling in new `webrtc-ab.js`
- `StartA` and `StartB` now have console-log defaults and require no arguments
- use shared script in `top.html` and `index.html` with default `StartA()`/`StartB()` calls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689875ababe8832c8f24c4c4396b7ab6