### PR TITLE
Enable detection mask preview for RTC top camera

### DIFF
--- a/top.html
+++ b/top.html
@@ -26,6 +26,7 @@
       </div>
       <div class="cam" id="topCam">
         <video id="topVid" autoplay playsinline></video>
+        <canvas id="topTex"></canvas>
         <canvas id="topOv" class="overlay"></canvas>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Show WebGPU detection mask in rtc-top view using a new `topTex` canvas
- Render mask texture during detection with preview flag support

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a27440c78832cb8d37fa36158d620