### PR TITLE
Fix empty team dropdowns in rtc-top setup

### DIFF
--- a/rtc-top.js
+++ b/rtc-top.js
@@ -198,6 +198,16 @@
       topRoiWInp.value = topROI.w;
       selA.value = cfg.teamA;
       selB.value = cfg.teamB;
+      if (selA.selectedIndex === -1) {
+        selA.selectedIndex = 0;
+        cfg.teamA = selA.value;
+        Config.save('teamA', cfg.teamA);
+      }
+      if (selB.selectedIndex === -1) {
+        selB.selectedIndex = 0;
+        cfg.teamB = selB.value;
+        Config.save('teamB', cfg.teamB);
+      }
 
       topMinInp.addEventListener('input', e => {
         cfg.topMinArea = Math.max(0, +e.target.value);


### PR DESCRIPTION
## Summary
- Ensure team dropdowns always select a valid team, defaulting to first option when stored value is invalid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check rtc-top.js`

------
https://chatgpt.com/codex/tasks/task_e_689a36b1c4a0832cb9b7f5b15b9b701f