### PR TITLE
Use RGBA format for top texture

### DIFF
--- a/top.js
+++ b/top.js
@@ -338,7 +338,11 @@
       const canvasFormat = navigator.gpu.getPreferredCanvasFormat();
       const texUsage1 = GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT;
       const maskUsage = GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST;
-      frameTex1 = device.createTexture({ size:[cfg.topResW,cfg.topResH], format: canvasFormat, usage: texUsage1 });
+      frameTex1 = device.createTexture({
+        size: [cfg.topResW, cfg.topResH],
+        format: 'rgba8unorm', // use explicit RGBA format instead of platform canvas format
+        usage: texUsage1
+      });
       maskTex1  = device.createTexture({ size:[cfg.topResW,cfg.topResH], format:'rgba8unorm', usage:maskUsage });
       sampler   = device.createSampler();
       uni   = device.createBuffer({ size:64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });


### PR DESCRIPTION
## Summary
- Force WebGPU top camera texture to use explicit `rgba8unorm` format rather than platform canvas format

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9322a010832cb20e799ea1842192