### PR TITLE
Clamp MJPEG origin and label command encoder

### DIFF
--- a/app.js
+++ b/app.js
@@ -681,7 +681,7 @@ const Detect = (() => {
   async function detectPass(source, feed, rect, flags, preview, which, origin = { x: 0, y: 0 }, flipY = true) {
     pack.resetStats(device.queue);
     GPUShared.copyFrame(device.queue, source, feed, origin, flipY);
-    const enc = device.createCommandEncoder();
+    const enc = device.createCommandEncoder({ label: which ? `enc-${which}` : 'enc' });
     GPUShared.clearMask(enc, feed);
     pack.writeUniform(device.queue, cfg.f16Ranges[cfg.teamA], cfg.f16Ranges[cfg.teamB], rect, flags);
     GPUShared.encodeCompute(enc, pipelines, feed, pack);
@@ -694,7 +694,8 @@ const Detect = (() => {
 
   async function runTopDetection(preview) {
     const src = Feeds.top();
-    const srcY = Math.floor((src.naturalHeight - cfg.TOP_H) / 2);
+    const raw = (src?.naturalHeight ?? cfg.TOP_H) - cfg.TOP_H;
+    const srcY = Math.max(0, Math.floor(raw / 2));
     const flagsTop = (preview ? FLAG_PREVIEW : 0) | FLAG_TEAM_A_ACTIVE | FLAG_TEAM_B_ACTIVE;
     const { a, b } = await detectPass(src, feedTop, rectTop(), flagsTop, preview, 'top', { x: 0, y: srcY }, true);
     const cntA = a[0], cntB = b[0];

--- a/gpu.html
+++ b/gpu.html
@@ -147,7 +147,7 @@
   /* 🔵 */ 0.50, 0.3, 0.20, 0.7, 1, 1,
   /* 🟢 */ 0.70, 0.6, 0.25, 0.9, 1, 1
     ]);
-    const savedCT = localStorage.getItem('TOP_COLOR_TABLE');
+    const savedCT = localStorage.getItem('COLOR_TABLE');
     if (savedCT) {
       try {
         const arr = JSON.parse(savedCT);
@@ -240,7 +240,7 @@
       inp.addEventListener('input', e => {
         const base = TEAM_INDICES[cfg.teamA] * 6 + i;
         COLOR_TABLE[base] = parseFloat(e.target.value);
-        localStorage.setItem('TOP_COLOR_TABLE',
+        localStorage.setItem('COLOR_TABLE',
           JSON.stringify(Array.from(COLOR_TABLE, v => +v.toFixed(2))));
         cfg.f16Ranges[cfg.teamA] = hsvRangeF16(cfg.teamA);
       });

--- a/top.js
+++ b/top.js
@@ -46,7 +46,7 @@
     /* blue   */ 0.50, 0.4, 0.4, 0.70, 1.00, 1.00,
     /* green  */ 0.70, 0.2, 0.2, 0.90, 1.00, 1.00
   ]);
-    const savedCT = localStorage.getItem('TOP_COLOR_TABLE');
+    const savedCT = localStorage.getItem('COLOR_TABLE');
   if (savedCT) {
     try {
       const arr = JSON.parse(savedCT);
@@ -290,7 +290,7 @@
         inp.addEventListener('input', e => {
           const base = TEAM_INDICES[cfg.teamA] * 6 + i;
           COLOR_TABLE[base] = parseFloat(e.target.value);
-            localStorage.setItem('TOP_COLOR_TABLE',
+            localStorage.setItem('COLOR_TABLE',
               JSON.stringify(Array.from(COLOR_TABLE, v => +v.toFixed(2))));
           cfg.f16Ranges[cfg.teamA] = hsvRangeF16(cfg.teamA);
         });


### PR DESCRIPTION
## Summary
- Clamp the MJPEG crop origin to prevent negative values
- Label the command encoder for easier debugging
- Use unified COLOR_TABLE key for threshold UI storage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a05c659ba8832ca946bfe9a7c0b5ea