### PR TITLE
refactor: simplify color helpers

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ const COLOR_EMOJI = {
   green: '🟢',
   blue: '🔵'
 };
-const { hsvRange, hsvRangeF16 } = GPUShared.createColorHelpers(TEAM_INDICES, COLOR_TABLE);
+const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
 
 const DEFAULTS = {
   topResW: 640,

--- a/gpu-shared.js
+++ b/gpu-shared.js
@@ -161,18 +161,11 @@
     pass.end();
   }
 
-  function createColorHelpers(teamIndices, colorTable) {
-    function hsvRange(team) {
-      const i = teamIndices[team] * 6;
-      return colorTable.subarray(i, i + 6);
-    }
-    function hsvRangeF16(team) {
-      const src = hsvRange(team);
-      const dst = new Uint16Array(6);
-      for (let i = 0; i < 6; i++) dst[i] = float32ToFloat16(src[i]);
-      return dst;
-    }
-    return { hsvRange, hsvRangeF16 };
+  function hsvRangeF16(teamIndices, colorTable, team) {
+    const i = teamIndices[team] * 6;
+    const dst = new Uint16Array(6);
+    for (let j = 0; j < 6; j++) dst[j] = float32ToFloat16(colorTable[i + j]);
+    return dst;
   }
 
   const GPUShared = {
@@ -186,7 +179,7 @@
     encodeCompute,
     drawMaskTo,
     float32ToFloat16,
-    createColorHelpers
+    hsvRangeF16
   };
 
   global.GPUShared = GPUShared;

--- a/gpu.html
+++ b/gpu.html
@@ -172,7 +172,7 @@
       } catch (e) { }
     }
     const COLOR_EMOJI = { red: '🔴', yellow: '🟡', blue: '🔵', green: '🟢' };
-    const { hsvRange, hsvRangeF16 } = GPUShared.createColorHelpers(TEAM_INDICES, COLOR_TABLE);
+    const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
     const { PREVIEW: FLAG_PREVIEW, TEAM_A: FLAG_TEAM_A_ACTIVE, TEAM_B: FLAG_TEAM_B_ACTIVE } =
       GPUShared.FLAGS;
 

--- a/top.js
+++ b/top.js
@@ -56,7 +56,7 @@
   } catch(e){}
   }
   const COLOR_EMOJI = { red: '🔴', yellow: '🟡', green: '🟢', blue: '🔵' };
-  const { hsvRange, hsvRangeF16 } = GPUShared.createColorHelpers(TEAM_INDICES, COLOR_TABLE);
+  const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
 
   // Detection flag bits (subset from app.js)
   const { PREVIEW: FLAG_PREVIEW, TEAM_A: FLAG_TEAM_A_ACTIVE, TEAM_B: FLAG_TEAM_B_ACTIVE } =


### PR DESCRIPTION
## Summary
- expose `hsvRangeF16` directly from GPUShared and drop color helper factory
- update app, top and gpu scripts to call `hsvRangeF16` directly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a07d314e38832ca3938b87e591dcca