### PR TITLE
Fix initialization on GPU configuration page

### DIFF
--- a/gpu.html
+++ b/gpu.html
@@ -133,7 +133,10 @@
       handleLog('ERR: ' + (err && (err.stack || err)));
     }
 
-    StartA().then(handleStartCtrl).catch(handleStartError);
+    function startRTC() {
+      StartA().then(handleStartCtrl).catch(handleStartError);
+    }
+    window.addEventListener('load', startRTC);
 
     function sendBit(bit) {
       if (dc && dc.readyState === 'open') {


### PR DESCRIPTION
## Summary
- Delay StartA invocation until after page load so `gpu.html` UI initializes correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0944d06d0832c90bc54840777e784