### PR TITLE
Initialize functions inline instead of onload handlers

### DIFF
--- a/gpu.html
+++ b/gpu.html
@@ -133,9 +133,7 @@
       handleLog('ERR: ' + (err && (err.stack || err)));
     }
 
-    window.addEventListener('load', () => {
-      StartA().then(handleStartCtrl).catch(handleStartError);
-    });
+    StartA().then(handleStartCtrl).catch(handleStartError);
 
     function sendBit(bit) {
       if (dc && dc.readyState === 'open') {

--- a/top.js
+++ b/top.js
@@ -542,5 +542,5 @@
     return { start };
   })();
 
-  window.addEventListener('DOMContentLoaded', () => Controller.start());
+  Controller.start();
 })();


### PR DESCRIPTION
## Summary
- inline StartA initialization in `gpu.html`
- call `Controller.start()` directly in `top.js`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a09a118028832c954ed9320cc13063