### PR TITLE
Ensure StartA is invoked in gpu.html without load listener

### DIFF
--- a/gpu.html
+++ b/gpu.html
@@ -92,7 +92,7 @@
     <span id="info"></span>
   </div>
 
-  <script src="webrtc.js" defer></script>
+  <script src="webrtc.js"></script>
   <script src="config.js"></script>
   <script src="gpu-shared.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Load `webrtc.js` synchronously in `gpu.html` so that `StartA` runs immediately without relying on an `onload` handler.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a09d50c390832cb051b6f8930c2104