### PR TITLE
refactor: centralize utilities

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,24 +150,7 @@ const PreviewGfx = (() => {
 })();
 
 
-function clampInt(val, min, max) {
-  val = Math.round(Number(val));
-  if (!Number.isFinite(val)) val = 0;
-  if (min !== undefined && val < min) val = min;
-  if (max !== undefined && val > max) val = max;
-  return val;
-}
 
-function populateTeamSelects(selA, selB) {
-  for (const [team, emoji] of Object.entries(COLOR_EMOJI)) {
-    const optA = document.createElement('option');
-    optA.value = team;
-    optA.textContent = emoji;
-    const optB = optA.cloneNode(true);
-    selA.appendChild(optA);
-    selB.appendChild(optB);
-  }
-}
 
 
 const Setup = (() => {
@@ -256,7 +239,7 @@ const Setup = (() => {
 
     function setHeight(h) {
       const resH = cfg[roi.keys.resH];
-      roi.h = clampInt(h, 10, resH);
+      roi.h = Math.round(u.clamp(Number(h), 10, resH));
       if (roi.maintainAspect) {
         const resW = cfg[roi.keys.resW];
         roi.w = roi.h * (resW / resH);
@@ -278,8 +261,8 @@ const Setup = (() => {
       } else if (roi.maintainAspect) {
         roi.w = roi.h * (resW / resH);
       }
-      roi.x = clampInt(roi.x, 0, resW - roi.w);
-      roi.y = clampInt(roi.y, 0, resH - roi.h);
+      roi.x = u.clamp(roi.x, 0, resW - roi.w);
+      roi.y = u.clamp(roi.y, 0, resH - roi.h);
       const x0 = Math.round(roi.x), y0 = Math.round(roi.y);
       const x1 = Math.round(roi.x + roi.w), y1 = Math.round(roi.y + roi.h);
       cfg[roi.keys.poly] = [[x0, y0], [x1, y0], [x1, y1], [x0, y1]];
@@ -419,7 +402,7 @@ const Setup = (() => {
   }
 
   function initInputs() {
-    populateTeamSelects(el.teamA, el.teamB);
+    populateTeamSelects(el.teamA, el.teamB, COLOR_EMOJI);
     thInputs = createThreshInputs(el.teamAThresh, onInputThresh);
     el.topMode.value = cfg.topMode;
     el.topUrl.value = cfg.url;
@@ -486,27 +469,27 @@ const Setup = (() => {
     Game.setTeams(cfg.teamA, cfg.teamB);
   }
 
-  function onChangeTopH(e) {
-    const h = clampInt(e.target.value, 10, cfg.topResH);
-    e.target.value = h;
-    TopROI.setHeight(h);
-  }
+    function onChangeTopH(e) {
+      const h = Math.round(u.clamp(Number(e.target.value), 10, cfg.topResH));
+      e.target.value = h;
+      TopROI.setHeight(h);
+    }
 
-  function onChangeFrontH(e) {
-    const h = clampInt(e.target.value, 10, cfg.frontResH);
-    e.target.value = h;
-    FrontROI.setHeight(h);
-  }
+    function onChangeFrontH(e) {
+      const h = Math.round(u.clamp(Number(e.target.value), 10, cfg.frontResH));
+      e.target.value = h;
+      FrontROI.setHeight(h);
+    }
 
-  function onInputTopMin(e) {
-    cfg.topMinArea = clampInt(e.target.value, 0);
-    Config.save('topMinArea', cfg.topMinArea);
-  }
+    function onInputTopMin(e) {
+      cfg.topMinArea = Math.round(u.clamp(Number(e.target.value), 0, Number.MAX_SAFE_INTEGER));
+      Config.save('topMinArea', cfg.topMinArea);
+    }
 
-  function onInputFrontMin(e) {
-    cfg.frontMinArea = clampInt(e.target.value, 0);
-    Config.save('frontMinArea', cfg.frontMinArea);
-  }
+    function onInputFrontMin(e) {
+      cfg.frontMinArea = Math.round(u.clamp(Number(e.target.value), 0, Number.MAX_SAFE_INTEGER));
+      Config.save('frontMinArea', cfg.frontMinArea);
+    }
 
   function onClickStart() {
     Controller.start();

--- a/gpu.html
+++ b/gpu.html
@@ -92,6 +92,7 @@
     <span id="info"></span>
   </div>
 
+  <script src="utils.js"></script>
   <script src="webrtc.js"></script>
   <script src="config.js"></script>
   <script src="gpu-shared.js"></script>
@@ -99,9 +100,8 @@
     (function () {
       'use strict';
       const { createConfig } = window;
-      const $ = id => document.getElementById(id);
-    const state = $('state');
-    const b0 = $('b0');
+    const state = $('#state');
+    const b0 = $('#b0');
 
     function handleOpen() {
       state.textContent = 'Connected';
@@ -136,17 +136,17 @@
     }
     window.sendBit = sendBit;
 
-      const info = $('info');
+    const info = $('#info');
       let infoBase = '';
       let lastFrameTS;
-    const start = $('start');
-    const canvas = $('gfx');
-    const widthInput = $('videoWidth');
-    const heightInput = $('videoHeight');
-    const minAreaInput = $('minArea');
-    const selA = $('teamA');
-    const selB = $('teamB');
-    const thCont = $('teamAThresh');
+    const start = $('#start');
+    const canvas = $('#gfx');
+    const widthInput = $('#videoWidth');
+    const heightInput = $('#videoHeight');
+    const minAreaInput = $('#minArea');
+    const selA = $('#teamA');
+    const selB = $('#teamB');
+    const thCont = $('#teamAThresh');
 
     const TEAM_INDICES = { red: 0, yellow: 1, blue: 2, green: 3 };
     const COLOR_TABLE = new Float32Array([
@@ -204,22 +204,7 @@
     heightInput.addEventListener('input', onHeightInput);
     minAreaInput.addEventListener('input', onMinAreaInput);
 
-    const fragA = document.createDocumentFragment();
-    const fragB = document.createDocumentFragment();
-    for (const t of Object.keys(TEAM_INDICES)) {
-      const optA = Object.assign(document.createElement('option'), {
-        value: t,
-        textContent: COLOR_EMOJI[t]
-      });
-      fragA.appendChild(optA);
-      const optB = Object.assign(document.createElement('option'), {
-        value: t,
-        textContent: COLOR_EMOJI[t]
-      });
-      fragB.appendChild(optB);
-    }
-    selA.appendChild(fragA);
-    selB.appendChild(fragB);
+    populateTeamSelects(selA, selB, COLOR_EMOJI);
     selA.value = cfg.teamA;
     selB.value = cfg.teamB;
     if (selA.selectedIndex === -1) {

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <div id="configScreen">
     </div>
   </div>
+    <script src="utils.js"></script>
     <script src="screen.js"></script>
     <script src="webrtc.js"></script>
     <script src="config.js"></script>

--- a/screen.js
+++ b/screen.js
@@ -1,16 +1,6 @@
 /*───────────────────────────────────────────────────────────
     Globals
 ───────────────────────────────────────────────────────────*/
-const domCache = {};
-window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
-
-window.u = Object.freeze({
-  rand   : n      => Math.random() * n,
-  pick   : arr    => arr[Math.floor(Math.random() * arr.length)],
-  between: (a, b) => a + Math.random() * (b - a),
-  clamp  : (n,l,h)=> n < l ? l : n > h ? h : n
-});
-
 const container = $('#container');
 
 /* current page index for ultra-fast hit routing */

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,20 @@
+/* Utility functions shared across game scripts */
+const domCache = {};
+window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
+
+window.u = Object.freeze({
+  rand   : n      => Math.random() * n,
+  pick   : arr    => arr[Math.floor(Math.random() * arr.length)],
+  between: (a, b) => a + Math.random() * (b - a),
+  clamp  : (n,l,h)=> n < l ? l : n > h ? h : n
+});
+
+window.populateTeamSelects = function (selA, selB, emojiMap) {
+  for (const [team, emoji] of Object.entries(emojiMap)) {
+    const opt = document.createElement('option');
+    opt.value = team;
+    opt.textContent = emoji;
+    selA.appendChild(opt);
+    selB.appendChild(opt.cloneNode(true));
+  }
+};


### PR DESCRIPTION
## Summary
- add utils.js with shared DOM helpers and team selectors
- include utils.js in app pages and swap local helpers for shared ones
- drop clampInt in favor of u.clamp

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2169242a4832c96ce11117060c619