### PR TITLE
Use Uint16 HSV arrays directly in detect

### DIFF
--- a/app.js
+++ b/app.js
@@ -568,7 +568,7 @@ const Detect = (() => {
     const { a, b } = await GPUShared.detect({
       key: 'top',
       source: Feeds.top(),
-      hsvA6: cfg.f16Ranges[cfg.teamA],  // still floats; GPUShared converts to f16
+      hsvA6: cfg.f16Ranges[cfg.teamA],  // Uint16Array f16 thresholds
       hsvB6: cfg.f16Ranges[cfg.teamB],
       rect: rectTop(),
       previewCanvas: preview ? document.getElementById('topTex') : null,

--- a/gpu-shared.js
+++ b/gpu-shared.js
@@ -216,10 +216,11 @@
     const FLAGS_PREVIEW = 1, FLAGS_A = 2, FLAGS_B = 4;
     const flags = (preview ? FLAGS_PREVIEW : 0) | (activeA ? FLAGS_A : 0) | (activeB ? FLAGS_B : 0);
 
-    for (let i = 0; i < 6; i++) {
-      ctx.pack.hA[i] = float32ToFloat16(hsvA6[i]);
-      ctx.pack.hB[i] = float32ToFloat16(hsvB6[i]);
+    if (!(hsvA6 instanceof Uint16Array) || !(hsvB6 instanceof Uint16Array)) {
+      throw new Error('detect: hsvA6/hsvB6 must be Uint16Array');
     }
+    ctx.pack.hA.set(hsvA6);
+    ctx.pack.hB.set(hsvB6);
     ctx.pack.resetStats(device.queue);
     ctx.pack.writeUniform(device.queue, ctx.pack.hA, ctx.pack.hB, rect || ctx.defaultRect, flags);
 


### PR DESCRIPTION
## Summary
- Replace per-element float16 conversion with direct Uint16Array copies in GPUShared.detect
- Clarify caller comment that HSV ranges are provided as Uint16Array thresholds

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2d4625f88832cbb8399f8872ccec9