### PR TITLE
Port detect_rgb_roi WebGPU pipeline

### DIFF
--- a/detect_rgb_roi.js
+++ b/detect_rgb_roi.js
@@ -1,92 +1,53 @@
-
-// detect_rgb_roi.js
-// Minimal host-side wrapper for the RGB detector shader with ROI-local outputs.
-
-(function () {
-  const WG = { X: 16, Y: 16 };
+(async function (global) {
+  const WG_SIZE = { X: 16, Y: 16 };
   const FLAGS = { PREVIEW: 1, TEAM_A: 2, TEAM_B: 4 };
 
-  // Shared device helper (auto-inits if none passed)
-  let __device = null;
-  async function getDevice(passed) {
-    if (passed) return passed;
-    if (__device) return __device;
-    if (!('gpu' in navigator)) throw new Error('WebGPU not available');
-    const adapter = await navigator.gpu.requestAdapter();
-    if (!adapter) throw new Error('No WebGPU adapter');
-    __device = await adapter.requestDevice();
-    return __device;
+  async function createPipelines(device, { url = 'shader_rgb_roi.wgsl', elementId = null, format = 'rgba8unorm' } = {}) {
+    let code;
+    if (elementId) {
+      const el = document.getElementById(elementId);
+      code = el ? el.textContent : '';
+    } else {
+      code = await fetch(url).then(r => r.text());
+    }
+    const mod = device.createShaderModule({ code });
+    const pass1 = device.createComputePipeline({ layout: 'auto', compute: { module: mod, entryPoint: 'pass1' } });
+    const pass2 = device.createComputePipeline({ layout: 'auto', compute: { module: mod, entryPoint: 'pass2' } });
+    const render = device.createRenderPipeline({
+      layout: 'auto',
+      vertex: { module: mod, entryPoint: 'vs' },
+      fragment: { module: mod, entryPoint: 'fs', targets: [{ format }] },
+      primitive: { topology: 'triangle-list' }
+    });
+    return { pass1, pass2, render };
   }
 
-  async function init(device) {
-    const dev = await getDevice(device);
-    const module = dev.createShaderModule({ code: await (await fetch('shader_rgb_roi.wgsl')).text() });
+  function createUniformPack(device) {
+    const bestKey = device.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    const bestStats = device.createBuffer({ size: 16, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    const outRes = device.createBuffer({ size: 24, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const outRead = device.createBuffer({ size: 24, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    const uni = device.createBuffer({ size: 64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
 
-    const pass1 = dev.createComputePipeline({
-      layout: 'auto',
-      compute: { module, entryPoint: 'pass1' }
-    });
-    const pass2 = dev.createComputePipeline({
-      layout: 'auto',
-      compute: { module, entryPoint: 'pass2' }
-    });
-
-    // Storage buffers
-    const bestKey = dev.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
-    const bestStats = dev.createBuffer({ size: 16, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
-    const outRes = dev.createBuffer({ size: 24, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
-    const outRead = dev.createBuffer({ size: 24, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
-
-    // Uniform buffer (std140-like packing; we just write f32s in sequence)
-    const uniSize = 4 * ( // floats
-      (4) + // Team A
-      (4) + // Team B
-      (2) + // rMin
-      (2) + // rMax
-      1 +   // flags (u32)
-      1 +   // radius
-      2     // pad
-    );
-    const uni = dev.createBuffer({ size: uniSize, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
-
-    // A mask/overlay texture for preview (RGBA8)
-    function makeTextures(w, h) {
-      const frameTex = dev.createTexture({
-        size: { width: w, height: h },
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT
-      });
-      const maskTex = dev.createTexture({
-        size: { width: w, height: h },
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
-      });
-      return { frameTex, maskTex };
+    function reset(queue) {
+      queue.writeBuffer(bestKey, 0, new Uint32Array([0]));
     }
 
     function writeUniform(queue, thrA, thrB, rect, flags, radiusPx) {
-      // pack floats in the same order as WGSL struct
-      const f32 = new Float32Array(uniSize / 4);
+      const f32 = new Float32Array(16);
       let o = 0;
-      // Team A
-      f32[o++] = thrA.minDom;  f32[o++] = thrA.yMin;  f32[o++] = thrA.knee;  f32[o++] = thrA.primary;
-      // Team B
-      f32[o++] = thrB.minDom;  f32[o++] = thrB.yMin;  f32[o++] = thrB.knee;  f32[o++] = thrB.primary;
-      // ROI
-      f32[o++] = rect.min[0];  f32[o++] = rect.min[1];
-      f32[o++] = rect.max[0];  f32[o++] = rect.max[1];
-      // flags + radius (treat flags as f32 then rewrite the 5th 32-bit slot as u32)
-      const byteView = new Uint8Array(f32.buffer);
+      f32[o++] = thrA.minDom; f32[o++] = thrA.yMin; f32[o++] = thrA.knee; f32[o++] = thrA.primary;
+      f32[o++] = thrB.minDom; f32[o++] = thrB.yMin; f32[o++] = thrB.knee; f32[o++] = thrB.primary;
+      f32[o++] = rect.min[0]; f32[o++] = rect.min[1];
+      f32[o++] = rect.max[0]; f32[o++] = rect.max[1];
       const u32 = new Uint32Array(f32.buffer);
       u32[o++] = flags >>> 0;
       f32[o++] = radiusPx;
-      // pad
       u32[o++] = 0; u32[o++] = 0;
-
       queue.writeBuffer(uni, 0, f32.buffer);
     }
 
-    async function readResult(buffer) {
+    async function readResult() {
       await outRead.mapAsync(GPUMapMode.READ);
       const d = new DataView(outRead.getMappedRange());
       const cx = d.getFloat32(0, true);
@@ -96,172 +57,211 @@
       const mass = d.getUint32(16, true);
       const ok = d.getUint32(20, true);
       outRead.unmap();
-      return { ok, cx, cy, r, iq, mass };
+      return { cx, cy, r, iq, mass, ok };
     }
 
-    return {
-      pipelines: { pass1, pass2 },
-      buffers: { bestKey, bestStats, outRes, outRead, uni },
-      makeTextures,
-      writeUniform,
-      readResult,
-      FLAGS,
-      device: dev
-    };
+    return { bestKey, bestStats, outRes, outRead, uni, reset, writeUniform, readResult };
   }
 
-function sizeOf(source) {
-  if ('videoWidth' in source) return { w: source.videoWidth, h: source.videoHeight };
-  if ('naturalWidth' in source) return { w: source.naturalWidth, h: source.naturalHeight };
-  if ('displayWidth' in source) return { w: source.displayWidth, h: source.displayHeight }; // VideoFrame
-  if ('codedWidth' in source)   return { w: source.codedWidth, h: source.codedHeight };     // VideoFrame
-  if ('width' in source && 'height' in source) return { w: source.width, h: source.height };
-  throw new Error('Unsupported source type for copyExternalImageToTexture()');
-}
+  function createFeed(device, pipelines, sampler, w, h) {
+    const texFormat = 'rgba8unorm';
+    const frameTex = device.createTexture({
+      size: { width: w, height: h },
+      format: texFormat,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
+    });
+    const maskTex = device.createTexture({
+      size: { width: w, height: h },
+      format: texFormat,
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
+    });
+    const frameView = frameTex.createView();
+    const maskView = maskTex.createView();
+
+    const renderBG = device.createBindGroup({
+      layout: pipelines.render.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: frameView },
+        { binding: 4, resource: maskView },
+        { binding: 5, resource: sampler }
+      ]
+    });
+
+    let bg1 = null, bg2 = null, pack1 = null, pack2 = null;
+    function computeBG1(pack) {
+      if (pack1 !== pack) {
+        bg1 = device.createBindGroup({
+          layout: pipelines.pass1.getBindGroupLayout(0),
+          entries: [
+            { binding: 0, resource: frameView },
+            { binding: 1, resource: maskView },
+            { binding: 2, resource: { buffer: pack.bestKey } },
+            { binding: 3, resource: { buffer: pack.bestStats } },
+            { binding: 6, resource: { buffer: pack.uni } }
+          ]
+        });
+        pack1 = pack;
+      }
+      return bg1;
+    }
+    function computeBG2(pack) {
+      if (pack2 !== pack) {
+        bg2 = device.createBindGroup({
+          layout: pipelines.pass2.getBindGroupLayout(0),
+          entries: [
+            { binding: 0, resource: frameView },
+            { binding: 1, resource: maskView },
+            { binding: 3, resource: { buffer: pack.bestStats } },
+            { binding: 4, resource: { buffer: pack.outRes } },
+            { binding: 6, resource: { buffer: pack.uni } }
+          ]
+        });
+        pack2 = pack;
+      }
+      return bg2;
+    }
+    function destroy() {
+      frameTex.destroy();
+      maskTex.destroy();
+    }
+    return { w, h, frameTex, maskTex, frameView, maskView, renderBG, computeBG1, computeBG2, destroy };
+  }
+
+  const _devState = new WeakMap();
+  let _device = null;
+  let _format = null;
+
+  async function _ensureDevice() {
+    if (_device) return _device;
+    if (!('gpu' in navigator)) throw new Error('WebGPU not supported');
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
+    if (!adapter) throw new Error('No WebGPU adapter');
+    _device = await adapter.requestDevice();
+    _format = navigator.gpu.getPreferredCanvasFormat?.() || 'rgba8unorm';
+    return _device;
+  }
+
+  function _sizeOf(src) {
+    const w = src?.codedWidth ?? src?.videoWidth ?? src?.naturalWidth ?? src?.width;
+    const h = src?.codedHeight ?? src?.videoHeight ?? src?.naturalHeight ?? src?.height;
+    return { w, h };
+  }
 
   async function detectRGB({
-    device,
-    source,               // HTMLVideoElement/ImageBitmap/HTMLCanvasElement/HTMLImageElement
-    thrA = { primary:0, minDom:0.12, yMin:0.10, knee:0.10 },
-    thrB = { primary:1, minDom:0.10, yMin:0.08, knee:0.10 },
+    key = 'default',
+    source,
+    thrA = { primary: 0, minDom: 0.12, yMin: 0.10, knee: 0.10 },
+    thrB = { primary: 1, minDom: 0.10, yMin: 0.08, knee: 0.10 },
     radiusPx = 16,
-    rect = null,          // { min:[x0,y0], max:[x1,y1] } in ABS coords
+    rect = null,
+    previewCanvas = null,
+    preview = false,
     activeA = true,
     activeB = true,
-    preview = false,
-    previewCanvas = null,
     flipY = true
   } = {}) {
-    const { w, h } = sizeOf(source);
-    if (!rect) rect = { min:[0,0], max:[w,h] };
+    const device = await _ensureDevice();
+    if (!source) throw new Error('detectRGB: source required');
 
-    const ctx = await init(device);
-    const dev = ctx.device;
-    const { frameTex, maskTex } = ctx.makeTextures(w, h);
+    let state = _devState.get(device);
+    if (!state) {
+      state = { pipelines: null, sampler: null, ctxByKey: new Map() };
+      _devState.set(device, state);
+    }
+    if (!state.pipelines) state.pipelines = await createPipelines(device, { format: _format });
+    if (!state.sampler) state.sampler = device.createSampler({ magFilter: 'nearest', minFilter: 'nearest' });
 
-    const frameView = frameTex.createView();
-    const maskView  = maskTex.createView();
+    let ctx = state.ctxByKey.get(key);
+    if (!ctx) {
+      const pack = createUniformPack(device);
+      ctx = { pack, feed: null, defaultRect: { min: new Float32Array([0, 0]), max: new Float32Array([0, 0]) }, canvasCtx: null };
+      state.ctxByKey.set(key, ctx);
+    }
 
-    // Copy the frame
-    dev.queue.copyExternalImageToTexture(
-      { source, flipY },
-      { texture: frameTex },
+    const { w, h } = _sizeOf(source);
+    if (!(w > 0 && h > 0)) throw new Error('detectRGB: bad source size');
+    let resized = false;
+    if (!ctx.feed || ctx.feed.w !== w || ctx.feed.h !== h) {
+      ctx.feed?.destroy?.();
+      ctx.feed = createFeed(device, state.pipelines, state.sampler, w, h);
+      ctx.defaultRect.max[0] = w;
+      ctx.defaultRect.max[1] = h;
+      resized = true;
+    }
+
+    if (!rect) rect = ctx.defaultRect;
+
+    device.queue.copyExternalImageToTexture(
+      { source, origin: { x: 0, y: 0 }, flipY },
+      { texture: ctx.feed.frameTex },
       { width: w, height: h }
     );
 
-    // Helper to run a single team
-    async function runFor(flags) {
-      // reset best key
-      dev.queue.writeBuffer(ctx.buffers.bestKey, 0, new Uint32Array([0]));
-      // write uniforms
-      ctx.writeUniform(dev.queue, thrA, thrB, rect, flags, radiusPx);
+    const baseFlags = (preview ? FLAGS.PREVIEW : 0);
+    let maskCleared = false;
 
-      const bindGroupLayout = ctx.pipelines.pass1.getBindGroupLayout(0);
-      // Create separate bind groups per pipeline to match their layouts.
-      // PASS 1 expected: 0 (texture_2d), 1 (storageTexture writeonly RGBA8), 3 (storage buf min 4), 4 (storage buf min 24), 6 (uniform)
-      const bgl1 = ctx.pipelines.pass1.getBindGroupLayout(0);
-      const bg1 = dev.createBindGroup({
-        layout: bgl1,
-        entries: [
-          { binding: 0, resource: frameView },
-          { binding: 1, resource: maskTex.createView() },
-          { binding: 2, resource: { buffer: ctx.buffers.bestKey } },
-          { binding: 3, resource: { buffer: ctx.buffers.bestStats } },
-          { binding: 6, resource: { buffer: ctx.buffers.uni } },
-        ],
-      });
-      // PASS 2 typically reduces + writes to outRes; it shouldn’t need textures.
-      // Expected bindings: 2: storage buffer, 3: storage buffer, 4: outRes storage buffer, 6: uniform
-      const bgl2 = ctx.pipelines.pass2.getBindGroupLayout(0);
-      const bg2 = dev.createBindGroup({
-        layout: bgl2,
-        entries: [
-          { binding: 0, resource: frameView },                         // texture_2d<f32>
-          { binding: 1, resource: maskView },                          // texture_storage_2d<rgba8unorm, write>
-          { binding: 3, resource: { buffer: ctx.buffers.bestStats } }, // array<u32>
-          { binding: 4, resource: { buffer: ctx.buffers.outRes } },    // struct OutRes
-          { binding: 6, resource: { buffer: ctx.buffers.uni } },       // uniforms
-         ],
-      });
+    async function runTeam(teamFlag) {
+      ctx.pack.reset(device.queue);
+      ctx.pack.writeUniform(device.queue, thrA, thrB, rect, baseFlags | teamFlag, radiusPx);
 
-      const enc = dev.createCommandEncoder();
-      // Clear mask if preview
-      if (preview) {
-        const rp = enc.beginRenderPass({
-          colorAttachments: [{ view: maskView, loadOp: 'clear', storeOp: 'store' }]
-        });
-        rp.end();
+      const enc = device.createCommandEncoder();
+      if (preview && !maskCleared) {
+        enc.beginRenderPass({ colorAttachments: [{ view: ctx.feed.maskView, loadOp: 'clear', storeOp: 'store' }] }).end();
+        maskCleared = true;
       }
       const c = enc.beginComputePass();
-      c.setPipeline(ctx.pipelines.pass1);
-      c.setBindGroup(0, bg1);
-      c.dispatchWorkgroups(Math.ceil(w / WG.X), Math.ceil(h / WG.Y)); // full grid, shader ignores outside ROI
-      c.setPipeline(ctx.pipelines.pass2);
-      c.setBindGroup(0, bg2);
+      c.setPipeline(state.pipelines.pass1);
+      c.setBindGroup(0, ctx.feed.computeBG1(ctx.pack));
+      c.dispatchWorkgroups(Math.ceil(w / WG_SIZE.X), Math.ceil(h / WG_SIZE.Y));
+      c.setPipeline(state.pipelines.pass2);
+      c.setBindGroup(0, ctx.feed.computeBG2(ctx.pack));
       c.dispatchWorkgroups(1, 1, 1);
       c.end();
-      enc.copyBufferToBuffer(ctx.buffers.outRes, 0, ctx.buffers.outRead, 0, 24);
-      dev.queue.submit([enc.finish()]);
-
-      return await ctx.readResult(ctx.buffers.outRead);
+      enc.copyBufferToBuffer(ctx.pack.outRes, 0, ctx.pack.outRead, 0, 24);
+      device.queue.submit([enc.finish()]);
+      return await ctx.pack.readResult();
     }
 
-    const base = (preview ? ctx.FLAGS.PREVIEW : 0);
-    let a = null, b = null, label = 'none';
+    let a = null, b = null;
+    if (activeA) a = await runTeam(FLAGS.TEAM_A);
+    if (activeB) b = await runTeam(FLAGS.TEAM_B);
 
-    if (activeA && !activeB) {
-      a = await runFor(base | ctx.FLAGS.TEAM_A);
-      label = a.ok ? 'a' : 'none';
-    } else if (!activeA && activeB) {
-      b = await runFor(base | ctx.FLAGS.TEAM_B);
-      label = b.ok ? 'b' : 'none';
-    } else {
-      a = await runFor(base | ctx.FLAGS.TEAM_A);
-      b = await runFor(base | ctx.FLAGS.TEAM_B);
-      if (a.ok && b.ok) label = 'both';
-      else if (a.ok) label = 'a';
-      else if (b.ok) label = 'b';
-    }
-
-    // Results are already ROI-local (shader subtracts rect.min)
-    const out = {
-      label,
-      a: a && a.ok ? { x: a.cx, y: a.cy, r: a.r } : null,
-      b: b && b.ok ? { x: b.cx, y: b.cy, r: b.r } : null,
-      roi: rect,
-      size: { w, h }
-    };
-
-    // Optional preview composited into previewCanvas by sampling frame+mask externally.
-    // --- Render frame + mask to the preview canvas (WebGPU) ---
     if (preview && previewCanvas) {
-      const swap = previewCanvas.getContext('webgpu');
-      if (swap) {
-        swap.configure({ device: dev, format: ctx.canvasFormat, alphaMode: 'premultiplied' });
-        const outView = swap.getCurrentTexture().createView();
-        const bglR = ctx.pipelines.render.getBindGroupLayout(0);
-        const bgR = dev.createBindGroup({
-          layout: bglR,
-          entries: [
-            { binding: 0, resource: frameView },           // tFrame
-            { binding: 4, resource: maskView },            // tMask (sampled)
-            { binding: 5, resource: dev.createSampler() }, // samp
-          ]
-        });
-        const enc2 = dev.createCommandEncoder();
-        const rp = enc2.beginRenderPass({
-          colorAttachments: [{ view: outView, loadOp: 'clear', storeOp: 'store' }]
-        });
-        rp.setPipeline(ctx.pipelines.render);
-        rp.setBindGroup(0, bgR);
-        rp.draw(3);
-        rp.end();
-        dev.queue.submit([enc2.finish()]);
+      if (!ctx.canvasCtx) {
+        ctx.canvasCtx = previewCanvas.getContext('webgpu');
+        previewCanvas.width = w;
+        previewCanvas.height = h;
+        ctx.canvasCtx.configure({ device, format: _format, alphaMode: 'opaque' });
+      } else if (resized) {
+        previewCanvas.width = w;
+        previewCanvas.height = h;
+        ctx.canvasCtx.configure({ device, format: _format, alphaMode: 'opaque' });
       }
+      const view = ctx.canvasCtx.getCurrentTexture().createView();
+      const enc = device.createCommandEncoder();
+      const r = enc.beginRenderPass({ colorAttachments: [{ view, loadOp: 'clear', storeOp: 'store' }] });
+      r.setPipeline(state.pipelines.render);
+      r.setBindGroup(0, ctx.feed.renderBG);
+      r.draw(3);
+      r.end();
+      device.queue.submit([enc.finish()]);
     }
 
-    return out;
+    let label = 'none';
+    if (a?.ok && b?.ok) label = 'both';
+    else if (a?.ok) label = 'a';
+    else if (b?.ok) label = 'b';
+
+    return {
+      label,
+      a: a?.ok ? { x: a.cx, y: a.cy, r: a.r } : null,
+      b: b?.ok ? { x: b.cx, y: b.cy, r: b.r } : null,
+      roi: rect,
+      size: { w, h },
+      resized
+    };
   }
 
-  window.GPUSharedRGB = { detectRGB, FLAGS };
-})();
+  global.GPUSharedRGB = { detectRGB, FLAGS };
+})(window);
+


### PR DESCRIPTION
## Summary
- Port full WebGPU compute-to-preview pipeline from detect.js to detect_rgb_roi.js
- Align compute bind groups with shader_rgb_roi.wgsl bindings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a70fc3a12c832cb43ec390110c9427