### PR TITLE
Handle VideoFrame visible rect size

### DIFF
--- a/detect.js
+++ b/detect.js
@@ -148,8 +148,10 @@
   }
 
   function _sizeOf(src) {
-    const w = src?.codedWidth ?? src?.videoWidth ?? src?.naturalWidth ?? src?.width;
-    const h = src?.codedHeight ?? src?.videoHeight ?? src?.naturalHeight ?? src?.height;
+    const w = src?.displayWidth ?? src?.visibleRect?.width ?? src?.codedWidth ??
+      src?.videoWidth ?? src?.naturalWidth ?? src?.width;
+    const h = src?.displayHeight ?? src?.visibleRect?.height ?? src?.codedHeight ??
+      src?.videoHeight ?? src?.naturalHeight ?? src?.height;
     return { w, h };
   }
 

--- a/detect_rgb_roi.js
+++ b/detect_rgb_roi.js
@@ -142,8 +142,10 @@
   }
 
   function _sizeOf(src) {
-    const w = src?.codedWidth ?? src?.videoWidth ?? src?.naturalWidth ?? src?.width;
-    const h = src?.codedHeight ?? src?.videoHeight ?? src?.naturalHeight ?? src?.height;
+    const w = src?.displayWidth ?? src?.visibleRect?.width ?? src?.codedWidth ??
+      src?.videoWidth ?? src?.naturalWidth ?? src?.width;
+    const h = src?.displayHeight ?? src?.visibleRect?.height ?? src?.codedHeight ??
+      src?.videoHeight ?? src?.naturalHeight ?? src?.height;
     return { w, h };
   }
 


### PR DESCRIPTION
## Summary
- avoid WebGPU copy errors by basing `_sizeOf` on `displayWidth`/`visibleRect` before `codedWidth`
- apply fix to ROI and base detection scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a30dcbc832ca01a2e8f2d3f242c