### PR TITLE
Enable f16 support for ROI shader

### DIFF
--- a/detect_rgb_roi.js
+++ b/detect_rgb_roi.js
@@ -136,7 +136,9 @@
     if (!('gpu' in navigator)) throw new Error('WebGPU not supported');
     const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
     if (!adapter) throw new Error('No WebGPU adapter');
-    _device = await adapter.requestDevice();
+    const requiredFeatures = [];
+    if (adapter.features?.has?.('shader-f16')) requiredFeatures.push('shader-f16');
+    _device = await adapter.requestDevice({ requiredFeatures });
     _format = navigator.gpu.getPreferredCanvasFormat?.() || 'rgba8unorm';
     return _device;
   }

--- a/shader_rgb_roi.wgsl
+++ b/shader_rgb_roi.wgsl
@@ -1,5 +1,5 @@
 
-//enable f16;
+enable f16;
 
 // ============================================================================
 // Fast RGB ball detector with ROI-local outputs


### PR DESCRIPTION
## Summary
- enable f16 in ROI shader
- request shader-f16 feature when creating WebGPU device

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a72dc36dcc832cb7090ae0a25a3fc6