### PR TITLE
refactor top page and setup crop logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -317,15 +317,7 @@ const Controller = (() => {
     Setup.bind();
     if (!await Feeds.init()) return;
     const cfg = Config.get();
-    const zEl = $('#frontZoom');
-    const z = Feeds.frontCropRatio();
-    zEl.value = z.toFixed(2);
-    cfg.frontZoom = z;
-    cfg.frontResW = Math.round(CAM_W / z) & ~1;
-    cfg.frontResH = Math.round(cfg.frontResW * ASPECT) & ~1;
-    Config.save('frontZoom', cfg.frontZoom);
-    Config.save('frontResW', cfg.frontResW);
-    Config.save('frontResH', cfg.frontResH);
+    Setup.updateFrontCrop();
     if (!await Detect.init()) return;
     lastTop = 0;
     if (cfg.topMode === TOP_MODE_MJPEG) {

--- a/setup.js
+++ b/setup.js
@@ -5,6 +5,7 @@
   let Config = App.Config;
   const PreviewGfx = App.PreviewGfx;
   const Controller = App.Controller;
+  const Feeds = App.Feeds;
   const TOP_MODE_MJPEG = 'mjpeg';
   const TOP_MODE_WEBRTC = 'webrtc';
   const TEAM_INDICES = { red: 0, green: 1, blue: 2, yellow: 3 };
@@ -218,6 +219,7 @@
             $('#start').disabled = false;
             return;
           }
+          updateFrontCrop();
           let busy = false;
           const loop = async () => {
             const frame = await Feeds.frontFrame();
@@ -447,8 +449,25 @@
         });
     }
 
+    function updateFrontCrop() {
+      if (!Feeds) return;
+      const cfg = Config.get();
+      const zEl = $('#frontZoom');
+      const z = Feeds.frontCropRatio();
+      if (zEl) zEl.value = z.toFixed(2);
+      cfg.frontZoom = z;
+      cfg.frontResW = Math.round(CAM_W / z) & ~1;
+      cfg.frontResH = Math.round(cfg.frontResW * ASPECT) & ~1;
+      Config.save('frontZoom', cfg.frontZoom);
+      Config.save('frontResW', cfg.frontResW);
+      Config.save('frontResH', cfg.frontResH);
+      if ($('#frontTex')) { $('#frontTex').width = cfg.frontResW; $('#frontTex').height = cfg.frontResH; }
+      if ($('#frontOv')) { $('#frontOv').width = cfg.frontResW; $('#frontOv').height = cfg.frontResH; }
+    }
+
     return {
       bind,
+      updateFrontCrop,
       get cfg() { return cfg; },
       get Config() { return Config; }
     };

--- a/top.html
+++ b/top.html
@@ -119,48 +119,7 @@
   <script src="detect.js"></script>
   <script src="feeds.js"></script>
   <script src="setup.js"></script>
-  <script>
-    (function () {
-      'use strict';
-      const state = $('#state');
-      const b0 = $('#b0');
-
-      function handleOpen() {
-        state.textContent = 'Connected';
-        b0.disabled = false;
-        b0.onclick = () => sendBit('0');
-      }
-
-      let dc;
-
-      function handleDcOpen() {
-        state.textContent = 'dc: open';
-        dc.send('hello from A');
-        handleOpen();
-      }
-
-      function handleStartCtrl(ctrl) {
-        dc = ctrl.channel;
-        if (!dc) { state.textContent = 'No data channel'; return; }
-        dc.onopen = handleDcOpen;
-        dc.onmessage = e => console.log('msg:', e.data);
-      }
-
-      StartA().then(handleStartCtrl).catch(err => {
-        state.textContent = 'ERR: ' + (err && (err.stack || err));
-      });
-
-      function sendBit(bit) {
-        if (dc && dc.readyState === 'open') {
-          dc.send(bit);
-          console.log(`[${new Date().toISOString()}] sent hit ${bit}`);
-        }
-      }
-      window.sendBit = sendBit;
-      Setup.bind();
-
-    })();
-  </script>
+  <script src="top.js"></script>
 
 </body>
 

--- a/top.js
+++ b/top.js
@@ -1,0 +1,48 @@
+(function () {
+  'use strict';
+
+  const Controller = (() => {
+    const state = $('#state');
+    const b0 = $('#b0');
+    let dc;
+
+    function handleOpen() {
+      state.textContent = 'Connected';
+      b0.disabled = false;
+      b0.onclick = () => sendBit('0');
+    }
+
+    function handleDcOpen() {
+      state.textContent = 'dc: open';
+      dc.send('hello from A');
+      handleOpen();
+    }
+
+    function handleStartCtrl(ctrl) {
+      dc = ctrl.channel;
+      if (!dc) { state.textContent = 'No data channel'; return; }
+      dc.onopen = handleDcOpen;
+      dc.onmessage = e => console.log('msg:', e.data);
+    }
+
+    function sendBit(bit) {
+      if (dc && dc.readyState === 'open') {
+        dc.send(bit);
+        console.log(`[${new Date().toISOString()}] sent hit ${bit}`);
+      }
+    }
+
+    function start() {
+      Setup.bind();
+      StartA().then(handleStartCtrl).catch(err => {
+        state.textContent = 'ERR: ' + (err && (err.stack || err));
+      });
+    }
+
+    return { start, sendBit };
+  })();
+
+  window.Top = { Controller };
+  window.sendBit = Controller.sendBit;
+  window.addEventListener('load', () => Controller.start());
+})();


### PR DESCRIPTION
## Summary
- extract top page inline WebRTC logic into new top.js module
- move front crop initialization from app.js into Setup.updateFrontCrop
- update top.html to load external controller script
- remove StartA wrapper and sync crop update logic in Setup

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b343ea3310832ca85e0007ff50b2d6