### PR TITLE
Apply dynamic crop on zoom input

### DIFF
--- a/feeds.js
+++ b/feeds.js
@@ -39,6 +39,7 @@
     const cfg = Config.get();
     let videoTop, track, dc, videoWorker;
     let lastFrame, cropRatio = 1;
+    let desiredW, desiredH;
 
     async function initRTC() {
       const stateEl = $('#state');
@@ -72,6 +73,8 @@
     async function init() {
       const reqResW = cfg.frontResW ?? cfg.topResW;
       const reqResH = cfg.frontResH ?? cfg.topResH;
+      desiredW = reqResW;
+      desiredH = reqResH;
 
       if (cfg.url || cfg.topMode) {
         const mode = cfg.topMode ?? TOP_MODE_WEBRTC;
@@ -120,8 +123,6 @@
         cropRatio = Math.max(w / reqResW, h / reqResH);
         const workerTrack = track.clone();
         videoWorker = startVideoWorker(workerTrack, (frame) => {
-          const desiredW = reqResW;
-          const desiredH = reqResH;
           let cropW = desiredW;
           let cropH = desiredH;
           const baseRect = frame.visibleRect || {
@@ -200,6 +201,11 @@
       return true;
     }
 
+    function setCrop(w, h) {
+      desiredW = w;
+      desiredH = h;
+    }
+
     return {
       init,
       top: () => videoTop,
@@ -208,7 +214,8 @@
         lastFrame = null;
         return frame;
       },
-      frontCropRatio: () => cropRatio
+      frontCropRatio: () => cropRatio,
+      setCrop
     };
   })();
 

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
           <button onclick="location.reload()">⟳</button>
           <button id="btnStart">►</button>
         </span>
-        <label for="frontZoom">🔍 <input id="frontZoom" type="number" step="0.01" style="width:3ch"></label>
+        <label for="frontZoom">🔍 <input id="frontZoom" type="number" step="0.01" min="1" style="width:3ch"></label>
         <label for="topMinInp">⚫ <input id="topMinInp" type="number" min="0" max="1" step="0.005" style="width:6ch"></label>
         <label for="topHInp">↕️ <input id="topHInp" type="number" min="10" step="1"></label>
         <label for="frontMinInp">⚫ <input id="frontMinInp" type="number" min="0" step="100" style="width:6ch"></label>

--- a/setup.js
+++ b/setup.js
@@ -27,6 +27,32 @@
   const Setup = (() => {
     let cfg;
 
+    function applyFrontZoom(val) {
+      if (!cfg) return;
+      cfg.frontZoom = Math.max(1, +val);
+      cfg.frontResW = Math.round(CAM_W / cfg.frontZoom) & ~1;
+      cfg.frontResH = Math.round(cfg.frontResW * ASPECT) & ~1;
+      Config.save('frontZoom', cfg.frontZoom);
+      Config.save('frontResW', cfg.frontResW);
+      Config.save('frontResH', cfg.frontResH);
+      if ($('#frontTex')) { $('#frontTex').width = cfg.frontResW; $('#frontTex').height = cfg.frontResH; }
+      if ($('#frontOv')) { $('#frontOv').width = cfg.frontResW; $('#frontOv').height = cfg.frontResH; }
+      Feeds?.setCrop?.(cfg.frontResW, cfg.frontResH);
+    }
+
+    function applyTopZoom(val) {
+      if (!cfg) return;
+      cfg.topZoom = Math.max(1, +val);
+      cfg.topResW = Math.round(CAM_W / cfg.topZoom) & ~1;
+      cfg.topResH = Math.round(cfg.topResW * ASPECT) & ~1;
+      Config.save('topZoom', cfg.topZoom);
+      Config.save('topResW', cfg.topResW);
+      Config.save('topResH', cfg.topResH);
+      if ($('#topTex')) { $('#topTex').width = cfg.topResW; $('#topTex').height = cfg.topResH; }
+      if ($('#topOv')) { $('#topOv').width = cfg.topResW; $('#topOv').height = cfg.topResH; }
+      Feeds?.setCrop?.(cfg.topResW, cfg.topResH);
+    }
+
     function initNumberSpinners() {
       document.querySelectorAll('input[type=number]:not([data-spinner])').forEach(input => {
         input.setAttribute('data-spinner', '');
@@ -107,28 +133,18 @@
         if ($('#topHInp')) $('#topHInp').max = cfg.topResH;
         if ($('#frontHInp')) $('#frontHInp').max = cfg.frontResH;
         $('#frontZoom')?.setAttribute('data-spinner', '');
-        if ($('#frontZoom')) $('#frontZoom').value = cfg.frontZoom;
-        $('#frontZoom')?.addEventListener('input', e => {
-          cfg.frontZoom = Math.max(1, +e.target.value);
-          cfg.frontResW = Math.round(CAM_W / cfg.frontZoom) & ~1;
-          cfg.frontResH = Math.round(cfg.frontResW * ASPECT) & ~1;
-          Config.save('frontZoom', cfg.frontZoom);
-          Config.save('frontResW', cfg.frontResW);
-          Config.save('frontResH', cfg.frontResH);
-          if ($('#frontTex')) { $('#frontTex').width = cfg.frontResW; $('#frontTex').height = cfg.frontResH; }
-          if ($('#frontOv')) { $('#frontOv').width = cfg.frontResW; $('#frontOv').height = cfg.frontResH; }
-        });
+        if ($('#frontZoom')) {
+          $('#frontZoom').value = cfg.frontZoom;
+          $('#frontZoom').addEventListener('input', e => {
+            applyFrontZoom(e.target.value);
+          });
+        }
         if ($('#zoom')) {
           $('#zoom').value = cfg.topZoom;
           $('#zoom').addEventListener('input', e => {
-          cfg.topZoom = Math.max(1, +e.target.value);
-          cfg.topResW = Math.round(CAM_W / cfg.topZoom) & ~1;
-          cfg.topResH = Math.round(cfg.topResW * ASPECT) & ~1;
-          Config.save('topZoom', cfg.topZoom);
-          Config.save('topResW', cfg.topResW);
-          Config.save('topResH', cfg.topResH);
-        });
-      }
+            applyTopZoom(e.target.value);
+          });
+        }
         if ($('#topMinInp')) {
           $('#topMinInp').value = cfg.topMinArea;
           $('#topMinInp').addEventListener('input', e => {
@@ -468,6 +484,8 @@
     return {
       bind,
       updateFrontCrop,
+      applyFrontZoom,
+      applyTopZoom,
       get cfg() { return cfg; },
       get Config() { return Config; }
     };

--- a/top.html
+++ b/top.html
@@ -80,7 +80,7 @@
     </fieldset>
     <fieldset>
       <button id="start">Start</button>
-      <input id="zoom" type="number" placeholder="zoom" step="0.01" />
+      <input id="zoom" type="number" placeholder="zoom" step="0.01" min="1" />
     </fieldset>
     <fieldset>
       <select id="teamA">


### PR DESCRIPTION
## Summary
- apply crop updates when zoom field changes in index and top pages
- expose zoom handlers in setup to update config and feed crop
- allow Feeds to adjust crop resolution dynamically
- move zoom inputs from inline handlers to JS arrow listeners

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b34a80be84832cb056bfd955454bd9