### PR TITLE
Reorder scripts and simplify startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -330,6 +330,6 @@ const Controller = (() => {
 
   return { start, setPreview, isPreview, handleBit };
 })();
-window.App = { Config, PreviewGfx, Feeds, Detect, Controller };
-window.addEventListener('load', () => Controller.start());
+window.App = { Config, PreviewGfx, Feeds, Detect, Controller, Setup: window.Setup };
+Controller.start();
 })();

--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
     <script src="detect.js"></script>
     <script src="game-engine.js"></script>
     <script src="feeds.js"></script>
-    <script src="app.js"></script>
     <script src="setup.js"></script>
+    <script src="app.js"></script>
     <script src="games/emoji.js"></script>
     <script src="games/balloon.js"></script>
     <script src="games/fish.js"></script>

--- a/setup.js
+++ b/setup.js
@@ -1,11 +1,7 @@
 (function () {
   'use strict';
 
-  const App = window.App || {};
-  let Config = App.Config;
-  const PreviewGfx = App.PreviewGfx;
-  const Controller = App.Controller;
-  const Feeds = App.Feeds;
+  let Config, PreviewGfx, Controller, Feeds;
   const TOP_MODE_MJPEG = 'mjpeg';
   const TOP_MODE_WEBRTC = 'webrtc';
   const TEAM_INDICES = { red: 0, green: 1, blue: 2, yellow: 3 };
@@ -98,6 +94,13 @@
     }
 
     function bind() {
+      if (!Config) {
+        const App = window.App || {};
+        Config = App.Config;
+        PreviewGfx = App.PreviewGfx;
+        Controller = App.Controller;
+        Feeds = App.Feeds;
+      }
       if (!Config) {
         const { createConfig } = window;
         const DEFAULT_CROP_W = 1280;


### PR DESCRIPTION
## Summary
- Load setup.js before app.js and include app in window.App
- Remove load event listener and invoke Controller.start directly
- Defer setup module references until app.js is available

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b34fcea0f0832cb46522dbf63f3a13