### PR TITLE
Ensure setup listeners bind when DOM ready

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -22,6 +22,7 @@
 
   const Setup = (() => {
     let cfg;
+    let bound = false;
 
     function applyFrontZoom(val) {
       if (!cfg) return;
@@ -94,6 +95,8 @@
     }
 
     function bind() {
+      if (bound) return;
+      bound = true;
       if (!Config) {
         const App = window.App || {};
         Config = App.Config;
@@ -496,4 +499,9 @@
 
   window.Setup = Setup;
   if (window.App) window.App.Setup = Setup;
+  if (document.readyState !== 'loading') {
+    Setup.bind();
+  } else {
+    window.addEventListener('DOMContentLoaded', () => Setup.bind(), { once: true });
+  }
 })();


### PR DESCRIPTION
## Summary
- Auto-bind setup UI listeners once the DOM is ready
- Prevent duplicate event bindings using a guard flag

## Testing
- `node --check setup.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3e4befa6c832cabb4b8546b294f03