### PR TITLE
Expose configuration and controllers globally

### DIFF
--- a/app.js
+++ b/app.js
@@ -330,6 +330,9 @@ const Controller = (() => {
 
   return { start, setPreview, isPreview, handleBit };
 })();
-window.App = { Config, PreviewGfx, Feeds, Detect, Controller, Setup: window.Setup };
+window.Config = Config;
+window.PreviewGfx = PreviewGfx;
+window.Detect = Detect;
+window.Controller = Controller;
 Controller.start();
 })();

--- a/feeds.js
+++ b/feeds.js
@@ -71,7 +71,7 @@
     }
 
     async function init() {
-      cfg = window.App?.Config?.get?.() || {};
+      cfg = window.Config?.get?.() || {};
       const reqResW = cfg.frontResW ?? cfg.topResW;
       const reqResH = cfg.frontResH ?? cfg.topResH;
       desiredW = reqResW;

--- a/game-engine.js
+++ b/game-engine.js
@@ -102,8 +102,8 @@ class BaseGame {
     this.container.className =
       'game' + (this.gameName ? ' ' + this.gameName : '');
 
-    if (win.App?.Config?.get) {
-      const cfg = win.App.Config.get();
+    if (win.Config?.get) {
+      const cfg = win.Config.get();
       Game.setTeams(cfg.teamA, cfg.teamB);
     }
   }

--- a/screen.js
+++ b/screen.js
@@ -18,8 +18,8 @@ function snapTo(i) {
   container.scrollTo({ top: index * PAGE_H(), behavior: 'smooth' });
   window.currentPage = index;          /* 0 launcher | 1 game | 2 config */
   container.dataset.page = index;      /* handy in DevTools */
-  if (i===2) App.Controller.setPreview(true);
-  else App.Controller.setPreview(false); 
+  if (i===2) Controller.setPreview(true);
+  else Controller.setPreview(false);
   if (i===1 && Game.current === -1) Game.run(u.pick(Game.list));
 }
 

--- a/setup.js
+++ b/setup.js
@@ -98,11 +98,10 @@
       if (bound) return;
       bound = true;
       if (!Config) {
-        const App = window.App || {};
-        Config = App.Config || Config;
-        PreviewGfx = App.PreviewGfx || PreviewGfx;
-        Controller = App.Controller || Controller;
-        Feeds = App.Feeds || window.Feeds;
+        Config = window.Config || Config;
+        PreviewGfx = window.PreviewGfx || PreviewGfx;
+        Controller = window.Controller || Controller;
+        Feeds = window.Feeds || Feeds;
       }
       if (!Config) {
         const { createConfig } = window;
@@ -492,13 +491,11 @@
       updateFrontCrop,
       applyFrontZoom,
       applyTopZoom,
-      get cfg() { return cfg; },
-      get Config() { return Config; }
+      get cfg() { return cfg; }
     };
   })();
 
   window.Setup = Setup;
-  if (window.App) window.App.Setup = Setup;
   if (document.readyState !== 'loading') {
     Setup.bind();
   } else {


### PR DESCRIPTION
## Summary
- export Config, Detect, and Controller directly on the window object
- initialize setup, feeds, and screen using global modules instead of App namespace
- load team settings in game engine via global Config

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f38deacc832c8a34de7266388a87