### PR TITLE
Set safe defaults for detection thresholds and ROI

### DIFF
--- a/feeds.js
+++ b/feeds.js
@@ -121,7 +121,10 @@
 
         track = frontStream.getVideoTracks()[0];
         const { width: w = reqResW, height: h = reqResH } = track.getSettings();
-        cropRatio = Math.max(w / reqResW, h / reqResH);
+        // Default to full-frame if requested size is missing
+        desiredW = desiredW || w;
+        desiredH = desiredH || h;
+        cropRatio = Math.max(w / desiredW, h / desiredH);
         const workerTrack = track.clone();
         videoWorker = startVideoWorker(workerTrack, (frame) => {
           let cropW = desiredW;

--- a/setup.js
+++ b/setup.js
@@ -14,10 +14,11 @@
   const CAM_W = 1920;
   const CAM_H = 886;
   const ASPECT = CAM_H / CAM_W;
-  const DOM_THR_DEFAULT = 0.10;
-  const SATMIN_DEFAULT  = 0.12;
-  const YMIN_DEFAULT    = 0.00;
-  const YMAX_DEFAULT    = 0.70;
+  // Detection thresholds: defaults must be at min or max range
+  const DOM_THR_DEFAULT = 0.0;
+  const SATMIN_DEFAULT  = 0.0;
+  const YMIN_DEFAULT    = 0.0;
+  const YMAX_DEFAULT    = 1.0;
   const RADIUS_DEFAULT  = 18;
 
   const Setup = (() => {
@@ -105,14 +106,21 @@
       }
       if (!Config) {
         const { createConfig } = window;
-        const DEFAULT_CROP_W = 1280;
-        const DEFAULT_CROP_H = Math.round(DEFAULT_CROP_W * ASPECT) & ~1;
-        const DEFAULT_ZOOM = CAM_W / DEFAULT_CROP_W;
+        // Default to full-frame, unity zoom
+        const DEFAULT_CROP_W = CAM_W;
+        const DEFAULT_CROP_H = CAM_H;
+        const DEFAULT_ZOOM = 1;
         const defaults = {
           topZoom: DEFAULT_ZOOM,
+          frontZoom: DEFAULT_ZOOM,
           topResW: DEFAULT_CROP_W,
           topResH: DEFAULT_CROP_H,
-          topMinArea: 0.025,
+          frontResW: DEFAULT_CROP_W,
+          frontResH: DEFAULT_CROP_H,
+          topH: DEFAULT_CROP_H,
+          frontH: DEFAULT_CROP_H,
+          topMinArea: 0,
+          frontMinArea: 0,
           teamA: 'green',
           teamB: 'blue',
           domThr: Array(4).fill(DOM_THR_DEFAULT),

--- a/top.html
+++ b/top.html
@@ -80,7 +80,7 @@
     </fieldset>
     <fieldset>
       <button id="start">Start</button>
-      <input id="zoom" type="number" placeholder="zoom" step="0.01" min="1" />
+      <input id="zoom" type="number" placeholder="zoom" step="0.01" min="1" value="1" />
     </fieldset>
     <fieldset>
       <select id="teamA">
@@ -89,10 +89,10 @@
         <option value="blue">🔵</option>
         <option value="yellow">🟡</option>
       </select>
-      <input id="domA" type="number" placeholder="domA" step="0.01" />
-      <input id="satMinA" type="number" placeholder="satMinA" step="0.01" />
-      <input id="yMinA" type="number" placeholder="yMinA" step="0.01" />
-      <input id="yMaxA" type="number" placeholder="yMaxA" step="0.01" />
+      <input id="domA" type="number" placeholder="domA" step="0.01" value="0" />
+      <input id="satMinA" type="number" placeholder="satMinA" step="0.01" value="0" />
+      <input id="yMinA" type="number" placeholder="yMinA" step="0.01" value="0" />
+      <input id="yMaxA" type="number" placeholder="yMaxA" step="0.01" value="1" />
     </fieldset>
     <fieldset>
       <select id="teamB">
@@ -101,14 +101,14 @@
         <option value="blue">🔵</option>
         <option value="yellow">🟡</option>
       </select>
-      <input id="domB" type="number" placeholder="domB" step="0.01" />
-      <input id="satMinB" type="number" placeholder="satMinB" step="0.01" />
-      <input id="yMinB" type="number" placeholder="yMinB" step="0.01" />
-      <input id="yMaxB" type="number" placeholder="yMaxB" step="0.01" />
+      <input id="domB" type="number" placeholder="domB" step="0.01" value="0" />
+      <input id="satMinB" type="number" placeholder="satMinB" step="0.01" value="0" />
+      <input id="yMinB" type="number" placeholder="yMinB" step="0.01" value="0" />
+      <input id="yMaxB" type="number" placeholder="yMaxB" step="0.01" value="1" />
     </fieldset>
     <fieldset>
-      <input id="radiusPx" type="number" placeholder="radius" />
-      <input id="topMinInp" type="number" placeholder="score thr (0..1)" step="0.005" />
+      <input id="radiusPx" type="number" placeholder="radius" value="18" />
+      <input id="topMinInp" type="number" placeholder="score thr (0..1)" step="0.005" value="0" />
     </fieldset>
     <span id="info"></span>
   </div>


### PR DESCRIPTION
## Summary
- Provide default values for all detection inputs and zoom to avoid zero-sized frames
- Initialize configuration with full-frame ROI, unity zoom, and neutral threshold ranges
- Default front camera crop to track size when specific dimensions are missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b400664e7c832c8d6230649b475d25