### PR TITLE
Ensure 1920x886 camera capture

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,10 +26,10 @@ const YMIN_DEFAULT    = 0.00;
 const YMAX_DEFAULT    = 0.70;
 const RADIUS_DEFAULT  = 18;
 
-// Camera runs at 19.5:9 (1920×886). Crop width is configurable but
+// Camera runs at 19.5:9 (1920×886 rounded even). Crop width is configurable but
 // height always maintains the aspect ratio.
 const CAM_W = 1920;
-const CAM_H = 886;
+const CAM_H = Math.round(CAM_W * 9 / 19.5) & ~1;
 const ASPECT = CAM_H / CAM_W;
 const DEFAULT_CROP_W = 1280;
 // iOS Safari requires even crop sizes when using VideoFrame visibleRect.

--- a/feeds.js
+++ b/feeds.js
@@ -4,6 +4,10 @@
   const TOP_MODE_MJPEG = 'mjpeg';
   const TOP_MODE_WEBRTC = 'webrtc';
 
+  const CAM_W = 1920;
+  const CAM_H = Math.round(CAM_W * 9 / 19.5) & ~1;
+  const ASPECT = CAM_H / CAM_W;
+
   function startVideoWorker(track, onFrame) {
     const workerSrc = `self.onmessage = async ({ data }) => {
   const post = frame => self.postMessage(frame, [frame]);
@@ -72,10 +76,10 @@
 
     async function init() {
       cfg = window.Config?.get?.() || {};
-      const reqResW = cfg.frontResW ?? cfg.topResW;
-      const reqResH = cfg.frontResH ?? cfg.topResH;
-      desiredW = reqResW;
-      desiredH = reqResH;
+      desiredW = cfg.frontResW ?? cfg.topResW ?? CAM_W;
+      desiredH = cfg.frontResH ?? cfg.topResH ?? Math.round(desiredW * ASPECT) & ~1;
+      const reqW = CAM_W;
+      const reqH = CAM_H;
 
       if (cfg.url || cfg.topMode) {
         const mode = cfg.topMode ?? TOP_MODE_WEBRTC;
@@ -108,8 +112,8 @@
         frontStream = await navigator.mediaDevices.getUserMedia({
           audio: false,
           video: {
-            width: { ideal: reqResW },
-            height: { ideal: reqResH },
+            width: { ideal: reqW },
+            height: { ideal: reqH },
             facingMode: 'environment',
             frameRate: { ideal: 60 }
           }

--- a/setup.js
+++ b/setup.js
@@ -12,7 +12,7 @@
     yellow: '🟡'
   };
   const CAM_W = 1920;
-  const CAM_H = 886;
+  const CAM_H = Math.round(CAM_W * 9 / 19.5) & ~1;
   const ASPECT = CAM_H / CAM_W;
   // Detection thresholds: defaults must be at min or max range
   const DOM_THR_DEFAULT = 0.0;


### PR DESCRIPTION
## Summary
- compute camera height using 19.5:9 aspect ratio with even rounding
- always request 1920x886 capture for front camera feeds

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b40777bcb4832c9b5d37c802bcbf4c