### PR TITLE
refactor: unify config structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,64 +7,8 @@
 (function () {
   'use strict';
 
-const TOP_MODE_MJPEG = 'mjpeg';
-const TOP_MODE_WEBRTC = 'webrtc';
-
-// front-camera (device camera)
-
-const TEAM_INDICES = { red: 0, green: 1, blue: 2, yellow: 3 };
-const COLOR_EMOJI = {
-  red: '🔴',
-  green: '🟢',
-  blue: '🔵',
-  yellow: '🟡'
-};
-
-const DOM_THR_DEFAULT = 0.10;
-const SATMIN_DEFAULT  = 0.12;
-const YMIN_DEFAULT    = 0.00;
-const YMAX_DEFAULT    = 0.70;
-const RADIUS_DEFAULT  = 18;
-
-// Camera runs at 19.5:9 (1920×886 rounded even). Crop width is configurable but
-// height always maintains the aspect ratio.
-const CAM_W = 1920;
-const CAM_H = Math.round(CAM_W * 9 / 19.5) & ~1;
-const ASPECT = CAM_H / CAM_W;
-const DEFAULT_CROP_W = 1280;
-// iOS Safari requires even crop sizes when using VideoFrame visibleRect.
-// Round and mask off the lowest bit to guarantee an even height.
-const DEFAULT_CROP_H = Math.round(DEFAULT_CROP_W * ASPECT) & ~1;
-const DEFAULT_ZOOM = CAM_W / DEFAULT_CROP_W;
-
-const DEFAULTS = {
-  topResW: 640,
-  topResH: 480,
-  frontZoom: DEFAULT_ZOOM,
-  frontResW: DEFAULT_CROP_W,
-  frontResH: DEFAULT_CROP_H,
-  topMinArea: 0.025,   // seed score threshold (0..1), was "area"
-  frontMinArea: 8000,  // no longer used for decisions, kept for UI compatibility
-  radiusPx: RADIUS_DEFAULT,
-  domThr: [DOM_THR_DEFAULT, DOM_THR_DEFAULT, DOM_THR_DEFAULT, DOM_THR_DEFAULT],
-  satMin: [SATMIN_DEFAULT, SATMIN_DEFAULT, SATMIN_DEFAULT, SATMIN_DEFAULT],
-  yMin:   [YMIN_DEFAULT,   YMIN_DEFAULT,   YMIN_DEFAULT,   YMIN_DEFAULT],
-  yMax:   [YMAX_DEFAULT,   YMAX_DEFAULT,   YMAX_DEFAULT,   YMAX_DEFAULT],
-  url:    "http://192.168.43.1:8080/video",
-  teamA:  "green",
-  teamB:  "blue",
-  polyT:  [],
-  polyF:  [],
-  topH:   160,
-  frontH: 220,
-  topMode: TOP_MODE_WEBRTC
-};
-
-const Config = createConfig(DEFAULTS);
-Config.load();
-const cfgInit = Config.get();
-cfgInit.frontResW = Math.round(CAM_W / (cfgInit.frontZoom || DEFAULT_ZOOM)) & ~1;
-cfgInit.frontResH = Math.round(cfgInit.frontResW * ASPECT) & ~1;
+const Config = window.Config;
+const { TOP_MODE_MJPEG, TEAM_INDICES } = Config.get();
 
 const PreviewGfx = (() => {
   const cfg = Config.get();
@@ -330,7 +274,6 @@ const Controller = (() => {
 
   return { start, setPreview, isPreview, handleBit };
 })();
-window.Config = Config;
 window.PreviewGfx = PreviewGfx;
 window.Detect = Detect;
 window.Controller = Controller;

--- a/feeds.js
+++ b/feeds.js
@@ -1,12 +1,6 @@
 (function () {
   'use strict';
 
-  const TOP_MODE_MJPEG = 'mjpeg';
-  const TOP_MODE_WEBRTC = 'webrtc';
-
-  const CAM_W = 1920;
-  const CAM_H = Math.round(CAM_W * 9 / 19.5) & ~1;
-  const ASPECT = CAM_H / CAM_W;
 
   function startVideoWorker(track, onFrame) {
     const workerSrc = `self.onmessage = async ({ data }) => {
@@ -40,7 +34,7 @@
   }
 
   const Feeds = (() => {
-    let cfg;
+    let Config, cfg;
     let videoTop, track, dc, videoWorker;
     let lastFrame, cropRatio = 1;
     let desiredW, desiredH;
@@ -75,9 +69,11 @@
     }
 
     async function init() {
-      cfg = window.Config?.get?.() || {};
+      Config = window.Config;
+      cfg = Config.get();
+      const { CAM_W, CAM_H, ASPECT, TOP_MODE_MJPEG, TOP_MODE_WEBRTC } = cfg;
       desiredW = cfg.frontResW ?? cfg.topResW ?? CAM_W;
-      desiredH = cfg.frontResH ?? cfg.topResH ?? Math.round(desiredW * ASPECT) & ~1;
+      desiredH = cfg.frontResH ?? cfg.topResH ?? toEvenInt(desiredW * ASPECT);
       const reqW = CAM_W;
       const reqH = CAM_H;
 

--- a/top-rgb.html
+++ b/top-rgb.html
@@ -95,12 +95,15 @@
   <script src="utils.js"></script>
   <script src="webrtc.js"></script>
   <script src="config.js"></script>
+  <script src="setup.js"></script>
   <!-- <script src="detect.js"></script> -->
    <script src="detect_rgb_roi.js"></script>
   <script>
     (function () {
       'use strict';
-      const { createConfig } = window;
+      Setup.bind();
+      const Config = window.Config;
+      const cfg = Config.get();
     const state = $('#state');
     const b0 = $('#b0');
 
@@ -148,60 +151,30 @@
     const selA = $('#teamA');
     const selB = $('#teamB');
     const thCont = $('#teamAThresh');
-
-    const TEAM_INDICES = { red: 0, yellow: 1, blue: 2, green: 3 };
-    const COLOR_TABLE = new Float32Array([
-  /* 🔴 */ 0.00, 0.6, 0.35, 0.1, 1, 1,
-  /* 🟡 */ 0.05, 0.7, 0.40, 0.2, 1, 1,
-  /* 🔵 */ 0.50, 0.3, 0.20, 0.7, 1, 1,
-  /* 🟢 */ 0.70, 0.6, 0.25, 0.9, 1, 1
-    ]);
-    const savedCT = localStorage.getItem('COLOR_TABLE');
-    if (savedCT) {
-      try {
-        const arr = JSON.parse(savedCT);
-        if (Array.isArray(arr) && arr.length === COLOR_TABLE.length) {
-          COLOR_TABLE.set(arr.map(Number));
-        }
-      } catch (e) { }
-    }
-    const COLOR_EMOJI = { red: '🔴', yellow: '🟡', blue: '🔵', green: '🟢' };
+    const { TEAM_INDICES, COLOR_EMOJI } = cfg;
+    const COLOR_TABLE = new Float32Array(cfg.COLOR_TABLE);
     // const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
     // RGB dominance presets for the new detector (simple & robust).
     const THR_PRESETS = {
-      red:    { primary: 0, minDom: 0.12, yMin: 0.10, knee: 0.10 },
-      yellow: { primary: 0, minDom: 0.08, yMin: 0.10, knee: 0.10 },
-      blue:   { primary: 2, minDom: 0.10, yMin: 0.08, knee: 0.10 },
-      green:  { primary: 1, minDom: 0.10, yMin: 0.08, knee: 0.10 }
+      red:   { primary: 0, minDom: 0.12, yMin: 0.10, knee: 0.10 },
+      green: { primary: 1, minDom: 0.10, yMin: 0.08, knee: 0.10 },
+      blue:  { primary: 2, minDom: 0.10, yMin: 0.08, knee: 0.10 },
+      yellow:{ primary: 0, minDom: 0.08, yMin: 0.10, knee: 0.10 }
     };
     const thrFor = (name) => THR_PRESETS[name] || THR_PRESETS.red;
     const radiusFromArea = (area) => Math.max(4, Math.sqrt(Math.max(0, area) / Math.PI));
-
-    const DEFAULTS = {
-      topResW: 1280,
-      topResH: 720,
-      topMinArea: 600,
-      teamA: 'green',
-      teamB: 'blue'
-    };
-
-    // const Config = createConfig(DEFAULTS);
-    // Config.load({ teamIndices: TEAM_INDICES, hsvRangeF16 });
-    const Config = createConfig(DEFAULTS);
-    Config.load({ teamIndices: TEAM_INDICES });
-    const cfg = Config.get();
 
     widthInput.value = cfg.topResW;
     heightInput.value = cfg.topResH;
     minAreaInput.value = cfg.topMinArea;
 
     function onWidthInput(e) {
-      cfg.topResW = Math.max(1, +e.target.value);
+      cfg.topResW = toEvenInt(Math.max(1, +e.target.value));
       Config.save('topResW', cfg.topResW);
     }
 
     function onHeightInput(e) {
-      cfg.topResH = Math.max(1, +e.target.value);
+      cfg.topResH = toEvenInt(Math.max(1, +e.target.value));
       Config.save('topResH', cfg.topResH);
     }
 
@@ -263,8 +236,8 @@
       const i = +e.target.dataset.idx;
       const base = TEAM_INDICES[cfg.teamA] * 6 + i;
       COLOR_TABLE[base] = parseFloat(e.target.value);
-      localStorage.setItem('COLOR_TABLE',
-        JSON.stringify(Array.from(COLOR_TABLE, v => +v.toFixed(2))));
+      Config.save('COLOR_TABLE',
+        Array.from(COLOR_TABLE, v => +v.toFixed(2)));
       // cfg.f16Ranges[cfg.teamA] = hsvRangeF16(cfg.teamA);
     }
 

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,9 @@
 const domCache = {};
 window.$ = sel => domCache[sel] || (domCache[sel] = document.querySelector(sel));
 
+// Round a number to the nearest even integer
+window.toEvenInt = n => Math.round(n) & ~1;
+
 window.u = Object.freeze({
   rand   : n      => Math.random() * n,
   pick   : arr    => arr[Math.floor(Math.random() * arr.length)],


### PR DESCRIPTION
## Summary
- consolidate constants and defaults into a single `DEFAULTS` object and persist missing keys via `Config`
- initialize feed module from shared `Config` to read settings consistently
- drop redundant global `Config` export from `app.js`
- add `toEvenInt` helper and apply it to all resolution calculations

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b72caafd20832ca79cc08fc4f43992