### PR TITLE
Refactor DOM interactions to use helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,28 +22,22 @@ const PreviewGfx = (() => {
   function ensureGPU(device) {
     if (!device) return;
     if (!ctxTopGPU) {
-      const c = $('#topTex');
-      if (c && typeof c.getContext === 'function') {
         try {
-          ctxTopGPU = c.getContext('webgpu');
+          ctxTopGPU = $('#topTex')?.getContext?.('webgpu');
           ctxTopGPU?.configure({ device, format: 'rgba8unorm', alphaMode: 'opaque' });
         } catch (err) {
           console.log('Top canvas WebGPU init failed', err);
           ctxTopGPU = null;
         }
-      }
     }
     if (!ctxFrontGPU) {
-      const c = $('#frontTex');
-      if (c && typeof c.getContext === 'function') {
         try {
-          ctxFrontGPU = c.getContext('webgpu');
+          ctxFrontGPU = $('#frontTex')?.getContext?.('webgpu');
           ctxFrontGPU?.configure({ device, format: 'rgba8unorm', alphaMode: 'opaque' });
         } catch (err) {
           console.log('Front canvas WebGPU init failed', err);
           ctxFrontGPU = null;
         }
-      }
     }
   }
 
@@ -134,7 +128,7 @@ const Detect = (() => {
       yMaxB: cfg.yMax[colorB],
       radiusPx: cfg.radiusPx,
       rect: rectTop(),
-      previewCanvas: preview ? document.getElementById('topTex') : null,
+        previewCanvas: preview ? $('#topTex') : null,
       preview,
       activeA: true,
       activeB: true,
@@ -154,10 +148,9 @@ const Detect = (() => {
     frontRunning = true;
     let frame;
     try {
-      frame = await Feeds.frontFrame();
-      if (!frame) return { detected: false, hits: [] };
-      const canvas = preview ? document.getElementById('frontTex') : null;
-      const colorA = TEAM_INDICES[cfg.teamA];
+        frame = await Feeds.frontFrame();
+        if (!frame) return { detected: false, hits: [] };
+        const colorA = TEAM_INDICES[cfg.teamA];
       const colorB = TEAM_INDICES[cfg.teamB];
       const { a, b, w, h, resized } = await GPUShared.detect({
         key: 'front',
@@ -174,16 +167,16 @@ const Detect = (() => {
         yMaxB: cfg.yMax[colorB],
         radiusPx: cfg.radiusPx,
         rect: rectFront(),
-        previewCanvas: canvas,
+          previewCanvas: preview ? $('#frontTex') : null,
         preview,
         activeA: aActive,
         activeB: bActive,
         flipY: true
       });
-      if (resized && canvas) {
-        canvas.width = frame.displayWidth;
-        canvas.height = frame.displayHeight;
-      }
+        if (resized && $('#frontTex')) {
+          $('#frontTex').width = frame.displayWidth;
+          $('#frontTex').height = frame.displayHeight;
+        }
       const [keyA, xA, yA] = a;
       const [keyB, xB, yB] = b;
       const hits = [];

--- a/detect.js
+++ b/detect.js
@@ -2,9 +2,9 @@
   const FLAGS = { PREVIEW: 1, TEAM_A: 2, TEAM_B: 4 };
 
   async function createPipelines(device, { url = 'shader.wgsl', elementId = null, format = 'rgba8unorm' } = {}) {
-    const code = elementId
-      ? document.getElementById(elementId)?.textContent || ''
-      : await fetch(url).then(r => r.text());
+      const code = elementId
+        ? $(`#${elementId}`)?.textContent || ''
+        : await fetch(url).then(r => r.text());
     const mod = device.createShaderModule({ code });
     // New entry points in WGSL: 'seed_grid' (sparse grid) and 'refine_micro' (tiny refine)
     const computeSeed = device.createComputePipeline({

--- a/detect_rgb_roi.js
+++ b/detect_rgb_roi.js
@@ -4,10 +4,9 @@
 
   async function createPipelines(device, { url = 'shader_rgb_roi.wgsl', elementId = null, format = 'rgba8unorm' } = {}) {
     let code;
-    if (elementId) {
-      const el = document.getElementById(elementId);
-      code = el ? el.textContent : '';
-    } else {
+      if (elementId) {
+        code = $(`#${elementId}`)?.textContent || '';
+      } else {
       code = await fetch(url).then(r => r.text());
     }
     const mod = device.createShaderModule({ code });

--- a/feeds.js
+++ b/feeds.js
@@ -55,8 +55,7 @@
     }
 
     async function initRTC() {
-      const stateEl = $('#state');
-      const log = msg => stateEl && (stateEl.textContent = String(msg));
+      const log = msg => $('#state') && ($('#state').textContent = String(msg));
       log('Connecting…');
 
       let ctrl;
@@ -93,14 +92,13 @@
 
       if (cfg.url || cfg.topMode !== undefined) {
         if (isMjpeg()) {
-          const urlWarnEl = $('#urlWarn');
           videoTop = new Image();
           videoTop.crossOrigin = 'anonymous';
           videoTop.src = cfg.url;
           try {
             await videoTop.decode();
           } catch (err) {
-            if (urlWarnEl) urlWarnEl.textContent = '⚠️';
+            $('#urlWarn')?.textContent = '⚠️';
             console.log('Failed to load top camera feed', err);
             return false;
           }

--- a/screen.js
+++ b/screen.js
@@ -1,23 +1,21 @@
 /*───────────────────────────────────────────────────────────
     Globals
 ───────────────────────────────────────────────────────────*/
-const container = $('#container');
-
 /* current page index for ultra-fast hit routing */
 window.currentPage = 0;
 
 /*───────────────────────────────────────────────────────────
     Three-page vertical pager  (0-launcher | 1-game | 2-config)
 ───────────────────────────────────────────────────────────*/
-const PAGE_H  = () => container.clientHeight;
+const PAGE_H  = () => $('#container').clientHeight;
 const MAX_IDX = 2;
 let   index   = 0;
 
 function snapTo(i) {
   index = Math.max(0, Math.min(i, MAX_IDX));
-  container.scrollTo({ top: index * PAGE_H(), behavior: 'smooth' });
+  $('#container').scrollTo({ top: index * PAGE_H(), behavior: 'smooth' });
   window.currentPage = index;          /* 0 launcher | 1 game | 2 config */
-  container.dataset.page = index;      /* handy in DevTools */
+  $('#container').dataset.page = index;      /* handy in DevTools */
   if (i===2) Controller.setPreview(true);
   else Controller.setPreview(false);
   if (i===1 && Game.current === -1) Game.run(u.pick(Game.list));
@@ -26,18 +24,18 @@ function snapTo(i) {
 /* global vertical swipe */
 let startY = null;
 
-container.addEventListener('pointerdown', e => {
+$('#container').addEventListener('pointerdown', e => {
   if (!e.isPrimary) return;
   if (window.currentPage === 2 || e.target.closest('#configScreen')) return;
   startY = e.clientY;
-  container.setPointerCapture(e.pointerId);   // guarantees pointerup
+  $('#container').setPointerCapture(e.pointerId);   // guarantees pointerup
 
   /* delegate hit to game engine */
   const team = e.button === 2 ? 0 : 1;
   if (window.Game?.routeHit) Game.routeHit(e.clientX, e.clientY, team);
 }, { passive: true });
 
-container.addEventListener('pointerup', e => {
+$('#container').addEventListener('pointerup', e => {
   if (startY == null) return;
   if (window.currentPage === 2 || e.target.closest('#configScreen')) { startY = null; return; }
   const dy = e.clientY - startY;
@@ -49,20 +47,16 @@ container.addEventListener('pointerup', e => {
 /*───────────────────────────────────────────────────────────
     Launcher page buttons  (page-0 only)
 ───────────────────────────────────────────────────────────*/
-const launcher = $('#launcher');
-
-if (launcher) {
-  launcher.addEventListener('click', e => {
-    const btn = e.target.closest('button');
-    if (!btn) return;
-    const game = btn.dataset.game;
-    if (game) {
-      Game.run(game);
-      snapTo(1); // jump to game page
-    } else if (btn.dataset.config !== undefined) {
-      snapTo(2); // jump to config page
-    }
-  });
-}
+$('#launcher')?.addEventListener('click', e => {
+  const btn = e.target.closest('button');
+  if (!btn) return;
+  const game = btn.dataset.game;
+  if (game) {
+    Game.run(game);
+    snapTo(1); // jump to game page
+  } else if (btn.dataset.config !== undefined) {
+    snapTo(2); // jump to config page
+  }
+});
 
 

--- a/setup.js
+++ b/setup.js
@@ -489,9 +489,8 @@
     function updateFrontCrop() {
       if (!Feeds) return;
       const cfg = Config.get();
-      const zEl = $('#frontZoom');
       const z = Feeds.frontCropRatio();
-      if (zEl) zEl.value = z.toFixed(2);
+      if ($('#frontZoom')) $('#frontZoom').value = z.toFixed(2);
       cfg.frontZoom = z;
               cfg.frontResW = toEvenInt(cfg.CAM_W / z);
               cfg.frontResH = toEvenInt(cfg.frontResW * cfg.ASPECT);

--- a/top-rgb.html
+++ b/top-rgb.html
@@ -104,33 +104,30 @@
       Setup.bind();
       const Config = window.Config;
       const cfg = Config.get();
-    const state = $('#state');
-    const b0 = $('#b0');
+      let dc;
 
-    function handleOpen() {
-      state.textContent = 'Connected';
-      b0.disabled = false;
-      b0.onclick = () => sendBit('0');
-    }
+      function handleOpen() {
+        $('#state').textContent = 'Connected';
+        $('#b0').disabled = false;
+        $('#b0').onclick = () => sendBit('0');
+      }
 
-    let dc;
+      function handleDcOpen() {
+        $('#state').textContent = 'dc: open';
+        dc.send('hello from A');
+        handleOpen();
+      }
 
-    function handleDcOpen() {
-      state.textContent = 'dc: open';
-      dc.send('hello from A');
-      handleOpen();
-    }
+      function handleStartCtrl(ctrl) {
+        dc = ctrl.channel;
+        if (!dc) { $('#state').textContent = 'No data channel'; return; }
+        dc.onopen = handleDcOpen;
+        dc.onmessage = e => console.log('msg:', e.data);
+      }
 
-    function handleStartCtrl(ctrl) {
-      dc = ctrl.channel;
-      if (!dc) { state.textContent = 'No data channel'; return; }
-      dc.onopen = handleDcOpen;
-      dc.onmessage = e => console.log('msg:', e.data);
-    }
-
-    StartA().then(handleStartCtrl).catch(err => {
-      state.textContent = 'ERR: ' + (err && (err.stack || err));
-    });
+      StartA().then(handleStartCtrl).catch(err => {
+        $('#state').textContent = 'ERR: ' + (err && (err.stack || err));
+      });
 
     function sendBit(bit) {
       if (dc && dc.readyState === 'open') {
@@ -140,98 +137,89 @@
     }
     window.sendBit = sendBit;
 
-    const info = $('#info');
       let infoBase = '';
       let lastFrameTS;
-    const start = $('#start');
-    const canvas = $('#gfx');
-    const widthInput = $('#videoWidth');
-    const heightInput = $('#videoHeight');
-    const minAreaInput = $('#minArea');
-    const selA = $('#teamA');
-    const selB = $('#teamB');
-    const thCont = $('#teamAThresh');
-    const TEAM_INDICES = window.TEAM_INDICES;
-    const COLOR_EMOJI = window.COLOR_EMOJI;
-    const COLOR_TABLE = new Float32Array(cfg.COLOR_TABLE);
-    // const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
-    // RGB dominance presets for the new detector (simple & robust).
-    const THR_PRESETS = {
-      red:   { primary: 0, minDom: 0.12, yMin: 0.10, knee: 0.10 },
-      green: { primary: 1, minDom: 0.10, yMin: 0.08, knee: 0.10 },
-      blue:  { primary: 2, minDom: 0.10, yMin: 0.08, knee: 0.10 },
-      yellow:{ primary: 0, minDom: 0.08, yMin: 0.10, knee: 0.10 }
-    };
-    const thrFor = (name) => THR_PRESETS[name] || THR_PRESETS.red;
-    const radiusFromArea = (area) => Math.max(4, Math.sqrt(Math.max(0, area) / Math.PI));
+      const TEAM_INDICES = window.TEAM_INDICES;
+      const COLOR_EMOJI = window.COLOR_EMOJI;
+      const COLOR_TABLE = new Float32Array(cfg.COLOR_TABLE);
+      // const hsvRangeF16 = t => GPUShared.hsvRangeF16(TEAM_INDICES, COLOR_TABLE, t);
+      // RGB dominance presets for the new detector (simple & robust).
+      const THR_PRESETS = {
+        red:   { primary: 0, minDom: 0.12, yMin: 0.10, knee: 0.10 },
+        green: { primary: 1, minDom: 0.10, yMin: 0.08, knee: 0.10 },
+        blue:  { primary: 2, minDom: 0.10, yMin: 0.08, knee: 0.10 },
+        yellow:{ primary: 0, minDom: 0.08, yMin: 0.10, knee: 0.10 }
+      };
+      const thrFor = (name) => THR_PRESETS[name] || THR_PRESETS.red;
+      const radiusFromArea = (area) => Math.max(4, Math.sqrt(Math.max(0, area) / Math.PI));
 
-    widthInput.value = cfg.topResW;
-    heightInput.value = cfg.topResH;
-    minAreaInput.value = cfg.topMinArea;
+      $('#videoWidth').value = cfg.topResW;
+      $('#videoHeight').value = cfg.topResH;
+      $('#minArea').value = cfg.topMinArea;
 
-    function onWidthInput(e) {
-      cfg.topResW = toEvenInt(Math.max(1, +e.target.value));
-      Config.save('topResW', cfg.topResW);
-    }
+      function onWidthInput(e) {
+        cfg.topResW = toEvenInt(Math.max(1, +e.target.value));
+        Config.save('topResW', cfg.topResW);
+      }
 
-    function onHeightInput(e) {
-      cfg.topResH = toEvenInt(Math.max(1, +e.target.value));
-      Config.save('topResH', cfg.topResH);
-    }
+      function onHeightInput(e) {
+        cfg.topResH = toEvenInt(Math.max(1, +e.target.value));
+        Config.save('topResH', cfg.topResH);
+      }
 
-    function onMinAreaInput(e) {
-      cfg.topMinArea = Math.max(0, +e.target.value);
-      Config.save('topMinArea', cfg.topMinArea);
-    }
+      function onMinAreaInput(e) {
+        cfg.topMinArea = Math.max(0, +e.target.value);
+        Config.save('topMinArea', cfg.topMinArea);
+      }
 
-    widthInput.addEventListener('input', onWidthInput);
-    heightInput.addEventListener('input', onHeightInput);
-    minAreaInput.addEventListener('input', onMinAreaInput);
+      $('#videoWidth').addEventListener('input', onWidthInput);
+      $('#videoHeight').addEventListener('input', onHeightInput);
+      $('#minArea').addEventListener('input', onMinAreaInput);
 
-    populateTeamSelects(selA, selB, COLOR_EMOJI);
-    selA.value = cfg.teamA;
-    selB.value = cfg.teamB;
-    if (selA.selectedIndex === -1) {
-      selA.selectedIndex = 0;
-      cfg.teamA = selA.value;
-      Config.save('teamA', cfg.teamA);
-    }
-    if (selB.selectedIndex === -1) {
-      selB.selectedIndex = 0;
-      cfg.teamB = selB.value;
-      Config.save('teamB', cfg.teamB);
-    }
+      populateTeamSelects($('#teamA'), $('#teamB'), COLOR_EMOJI);
+      $('#teamA').value = cfg.teamA;
+      $('#teamB').value = cfg.teamB;
+      if ($('#teamA').selectedIndex === -1) {
+        $('#teamA').selectedIndex = 0;
+        cfg.teamA = $('#teamA').value;
+        Config.save('teamA', cfg.teamA);
+      }
+      if ($('#teamB').selectedIndex === -1) {
+        $('#teamB').selectedIndex = 0;
+        cfg.teamB = $('#teamB').value;
+        Config.save('teamB', cfg.teamB);
+      }
 
-    function onChangeTeamA(e) {
-      cfg.teamA = e.target.value;
-      Config.save('teamA', cfg.teamA);
-      updateThreshInputs();
-    }
+      function onChangeTeamA(e) {
+        cfg.teamA = e.target.value;
+        Config.save('teamA', cfg.teamA);
+        updateThreshInputs();
+      }
 
-    function onChangeTeamB(e) {
-      cfg.teamB = e.target.value;
-      Config.save('teamB', cfg.teamB);
-    }
+      function onChangeTeamB(e) {
+        cfg.teamB = e.target.value;
+        Config.save('teamB', cfg.teamB);
+      }
 
-    selA.addEventListener('change', onChangeTeamA);
-    selB.addEventListener('change', onChangeTeamB);
+      $('#teamA').addEventListener('change', onChangeTeamA);
+      $('#teamB').addEventListener('change', onChangeTeamB);
 
-    const thInputs = [];
-    const thFrag = document.createDocumentFragment();
-    for (let i = 0; i < 6; i++) {
-      const inp = Object.assign(document.createElement('input'), {
-        type: 'number',
-        min: '0',
-        max: '1',
-        step: '0.05'
-      });
-      Object.assign(inp.style, { width: '4ch' });
-      inp.dataset.idx = i;
-      thInputs.push(inp);
-      thFrag.appendChild(inp);
-      inp.addEventListener('input', onThresholdInput);
-    }
-    thCont.appendChild(thFrag);
+      const thInputs = [];
+      const thFrag = document.createDocumentFragment();
+      for (let i = 0; i < 6; i++) {
+        const inp = Object.assign(document.createElement('input'), {
+          type: 'number',
+          min: '0',
+          max: '1',
+          step: '0.05'
+        });
+        Object.assign(inp.style, { width: '4ch' });
+        inp.dataset.idx = i;
+        thInputs.push(inp);
+        thFrag.appendChild(inp);
+        inp.addEventListener('input', onThresholdInput);
+      }
+      $('#teamAThresh').appendChild(thFrag);
 
     function onThresholdInput(e) {
       const i = +e.target.dataset.idx;
@@ -248,17 +236,17 @@
     }
     updateThreshInputs();
 
-    start.addEventListener('click', onStartClick);
+    $('#start').addEventListener('click', onStartClick);
 
     async function onStartClick() {
-      start.disabled = true;
+      $('#start').disabled = true;
       infoBase = '';
       try {
         // 1) Camera → WebCodecs VideoFrame (no <video> element)
         const videoConstraints = { facingMode: 'user', frameRate: { ideal: 60 } };
-        const w = parseInt(widthInput.value, 10);
+        const w = parseInt($('#videoWidth').value, 10);
         if (!isNaN(w)) videoConstraints.width = { ideal: w };
-        const h = parseInt(heightInput.value, 10);
+        const h = parseInt($('#videoHeight').value, 10);
         if (!isNaN(h)) videoConstraints.height = { ideal: h };
         const stream = await navigator.mediaDevices.getUserMedia({ video: videoConstraints, audio: false });
         const track = stream.getVideoTracks()[0];
@@ -316,7 +304,7 @@
           const now = performance.now();
           if (lastFrameTS !== undefined) {
             const fps = 1000 / (now - lastFrameTS);
-            info.textContent = `${infoBase} ${fps.toFixed(1)} fps`;
+            $('#info').textContent = `${infoBase} ${fps.toFixed(1)} fps`;
           }
           lastFrameTS = now;
           busy = true;
@@ -345,7 +333,7 @@
               thrB: thrFor(cfg.teamB),
               radiusPx,
               rect,
-              previewCanvas: canvas,
+              previewCanvas: $('#gfx'),
               preview: true,
               activeA: true,
               activeB: true,
@@ -355,11 +343,11 @@
             const resized = true;
 
             if (resized) {
-              canvas.width = frame.displayWidth;
-              canvas.height = frame.displayHeight;
+              $('#gfx').width = frame.displayWidth;
+              $('#gfx').height = frame.displayHeight;
               // infoBase = `Running ${w}×${h}, shader.wgsl compute+render (VideoFrame).`;
               infoBase = `Running ${w}×${h}, RGB grid+ring detector (VideoFrame).`;
-              info.textContent = infoBase;
+              $('#info').textContent = infoBase;
             }
 
             // const aOn = !!res?.ok && (res.mass > cfg.topMinArea);
@@ -383,8 +371,8 @@
         }
 
       } catch (err) {
-        info.textContent = (err && err.message) ? err.message : String(err);
-        start.disabled = false;
+        $('#info').textContent = (err && err.message) ? err.message : String(err);
+        $('#start').disabled = false;
         console.error(err);
       }
     }

--- a/top.js
+++ b/top.js
@@ -2,18 +2,16 @@
   'use strict';
 
   const Controller = (() => {
-    const state = $('#state');
-    const b0 = $('#b0');
     let dc;
 
     function handleOpen() {
-      state.textContent = 'Connected';
-      b0.disabled = false;
-      b0.onclick = () => sendBit('0');
+      $('#state').textContent = 'Connected';
+      $('#b0').disabled = false;
+      $('#b0').onclick = () => sendBit('0');
     }
-    
+
     function wireStartA() {
-      const log = msg => state && (state.textContent = String(msg));
+      const log = msg => $('#state') && ($('#state').textContent = String(msg));
       StartA({
         log,
         onOpen: (ch) => {

--- a/zoom.html
+++ b/zoom.html
@@ -130,32 +130,6 @@
 
 <script>
 (() => {
-  const els = {
-    start: document.getElementById('startBtn'),
-    stop: document.getElementById('stopBtn'),
-    torch: document.getElementById('torchBtn'),
-    video: document.getElementById('video'),
-    zSlider: document.getElementById('zoomSlider'),
-    zRead: document.getElementById('zoomRead'),
-    z1: document.getElementById('z1'),
-    z2: document.getElementById('z2'),
-    stabilize: document.getElementById('stabilizeBtn'),
-    delay: document.getElementById('delay'),
-    res: document.getElementById('res'),
-    trackZoom: document.getElementById('trackZoom'),
-    zoomSupport: document.getElementById('zoomSupport'),
-    torchSupport: document.getElementById('torchSupport'),
-    capEmu: document.getElementById('capEmu'),
-    capReal: document.getElementById('capReal'),
-    c1: document.getElementById('c1'),
-    c2: document.getElementById('c2'),
-    h1: document.getElementById('h1'),
-    h2: document.getElementById('h2'),
-    s1: document.getElementById('s1'),
-    s2: document.getElementById('s2'),
-    dl1: document.getElementById('dl1'),
-    dl2: document.getElementById('dl2'),
-  };
 
   let stream = null;
   let track = null;
@@ -165,24 +139,24 @@
   function clamp(v,min,max){return Math.max(min, Math.min(max, v));}
 
   function updateRes(){
-    const w = els.video.videoWidth || 0;
-    const h = els.video.videoHeight || 0;
-    els.res.textContent = w && h ? `${w}×${h}` : '—';
+    const w = $('#video').videoWidth || 0;
+    const h = $('#video').videoHeight || 0;
+    $('#res').textContent = w && h ? `${w}×${h}` : '—';
   }
 
   function setUIEnabled(on){
-    els.stop.disabled = !on;
-    els.capEmu.disabled = !on;
-    els.capReal.disabled = !on;
-    els.z1.disabled = !on;
-    els.z2.disabled = !on;
-    els.zSlider.disabled = !on;
-    els.torch.disabled = !on;
+    $('#stopBtn').disabled = !on;
+    $('#capEmu').disabled = !on;
+    $('#capReal').disabled = !on;
+    $('#z1').disabled = !on;
+    $('#z2').disabled = !on;
+    $('#zoomSlider').disabled = !on;
+    $('#torchBtn').disabled = !on;
   }
 
   async function start(){
     try{
-      els.start.disabled = true;
+      $('#startBtn').disabled = true;
       usingEmulatedZoom = false;
       stream = await navigator.mediaDevices.getUserMedia({
         video: {
@@ -193,8 +167,8 @@
         },
         audio: false
       });
-      els.video.srcObject = stream;
-      await els.video.play();
+      $('#video').srcObject = stream;
+      await $('#video').play();
       track = stream.getVideoTracks()[0];
 
       const caps = track.getCapabilities ? track.getCapabilities() : {};
@@ -202,30 +176,30 @@
       // Zoom support detection
       let zoomCap = caps.zoom;
       if (zoomCap && typeof zoomCap.min === 'number' && typeof zoomCap.max === 'number') {
-        els.zoomSupport.innerHTML = '<span class="ok">Yes</span>';
+        $('#zoomSupport').innerHTML = '<span class="ok">Yes</span>';
         const min = Math.max(1, zoomCap.min);
         const max = Math.max(min, zoomCap.max);
         const step = zoomCap.step || 0.01;
-        els.zSlider.min = String(min);
-        els.zSlider.max = String(max);
-        els.zSlider.step = String(step);
+        $('#zoomSlider').min = String(min);
+        $('#zoomSlider').max = String(max);
+        $('#zoomSlider').step = String(step);
         await applyZoom(1);
       } else {
-        els.zoomSupport.innerHTML = '<span class="warning">Emulated</span>';
+        $('#zoomSupport').innerHTML = '<span class="warning">Emulated</span>';
         usingEmulatedZoom = true;
-        els.zSlider.min = '1';
-        els.zSlider.max = '3';
-        els.zSlider.step = '0.01';
+        $('#zoomSlider').min = '1';
+        $('#zoomSlider').max = '3';
+        $('#zoomSlider').step = '0.01';
         applyEmulatedZoom(1);
       }
 
       // Torch support
       const torchOK = !!caps.torch;
-      els.torchSupport.textContent = torchOK ? 'Yes' : 'No';
-      els.torch.disabled = !torchOK;
+      $('#torchSupport').textContent = torchOK ? 'Yes' : 'No';
+      $('#torchBtn').disabled = !torchOK;
 
       setUIEnabled(true);
-      els.stop.disabled = false;
+      $('#stopBtn').disabled = false;
 
       updateRes();
       requestAnimationFrame(function raf(){updateRes(); requestAnimationFrame(raf)});
@@ -233,15 +207,15 @@
       // track zoom readout
       const upd = () => {
         const s = track.getSettings ? track.getSettings() : {};
-        const z = typeof s.zoom === 'number' ? s.zoom : (usingEmulatedZoom ? parseFloat(els.zSlider.value) : '—');
-        els.trackZoom.textContent = (z==='—')? '—' : `${(+z).toFixed(2)}×`;
+        const z = typeof s.zoom === 'number' ? s.zoom : (usingEmulatedZoom ? parseFloat($('#zoomSlider').value) : '—');
+        $('#trackZoom').textContent = (z==='—')? '—' : `${(+z).toFixed(2)}×`;
       };
       setInterval(upd, 250);
 
     }catch(err){
       console.error(err);
       alert('Could not start camera: ' + err.message);
-      els.start.disabled = false;
+      $('#startBtn').disabled = false;
     }
   }
 
@@ -249,11 +223,11 @@
     if(stream){
       stream.getTracks().forEach(t=>t.stop());
       stream = null; track = null;
-      els.video.srcObject = null;
+      $('#video').srcObject = null;
       setUIEnabled(false);
-      els.start.disabled = false;
-      els.res.textContent = '—';
-      els.trackZoom.textContent = '—';
+      $('#startBtn').disabled = false;
+      $('#res').textContent = '—';
+      $('#trackZoom').textContent = '—';
     }
   }
 
@@ -265,29 +239,29 @@
       await track.applyConstraints({ advanced: [{ zoom: z }] });
     }catch(e){
       try{ await track.applyConstraints({ zoom: z }); }
-      catch(e2){ console.warn('Zoom failed, emulating', e2); usingEmulatedZoom = true; applyEmulatedZoom(z); els.zoomSupport.innerHTML = '<span class="warning">Emulated</span>'; }
+      catch(e2){ console.warn('Zoom failed, emulating', e2); usingEmulatedZoom = true; applyEmulatedZoom(z); $('#zoomSupport').innerHTML = '<span class="warning">Emulated</span>'; }
     }
-    els.zSlider.value = String(z);
-    els.zRead.textContent = `${z.toFixed(2)}×`;
+    $('#zoomSlider').value = String(z);
+    $('#zoomRead').textContent = `${z.toFixed(2)}×`;
   }
 
   function applyEmulatedZoom(z){
     z = Math.max(1, parseFloat(z));
-    els.video.style.transform = `scale(${z})`;
-    els.zRead.textContent = `${z.toFixed(2)}× (emulated)`;
+    $('#video').style.transform = `scale(${z})`;
+    $('#zoomRead').textContent = `${z.toFixed(2)}× (emulated)`;
   }
 
   async function stabilize(){
-    const ms = parseInt(els.delay.value||0,10);
+    const ms = parseInt($('#delay').value||0,10);
     if (ms>0) await sleep(ms);
   }
 
   // Capture helper
   async function capture(toCanvas, {emulatedCrop=false}={}){
-    if(!els.video.videoWidth){ alert('Camera not ready yet.'); return; }
+    if(!$('#video').videoWidth){ alert('Camera not ready yet.'); return; }
     const ctx = toCanvas.getContext('2d');
-    const w = els.video.videoWidth;
-    const h = els.video.videoHeight;
+    const w = $('#video').videoWidth;
+    const h = $('#video').videoHeight;
     toCanvas.width = w; toCanvas.height = h;
 
     if (emulatedCrop){
@@ -296,9 +270,9 @@
       const sx = Math.floor((w - cropW)/2);
       const sy = Math.floor((h - cropH)/2);
       ctx.imageSmoothingEnabled = true;
-      ctx.drawImage(els.video, sx, sy, cropW, cropH, 0, 0, w, h);
+      ctx.drawImage($('#video'), sx, sy, cropW, cropH, 0, 0, w, h);
     } else {
-      ctx.drawImage(els.video, 0, 0, w, h);
+      ctx.drawImage($('#video'), 0, 0, w, h);
     }
   }
 
@@ -349,54 +323,54 @@
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url; a.download = name;
-      document.body.appendChild(a); a.click();
+      $('body').appendChild(a); a.click();
       setTimeout(()=>{ URL.revokeObjectURL(url); a.remove(); }, 500);
     }, 'image/png');
   }
 
   // wire up
-  els.start.addEventListener('click', start);
-  els.stop.addEventListener('click', stop);
-  els.zSlider.addEventListener('input', e => applyZoom(e.target.value));
-  els.z1.addEventListener('click', ()=>applyZoom(1));
-  els.z2.addEventListener('click', ()=>applyZoom(2));
-  els.stabilize.addEventListener('click', stabilize);
+  $('#startBtn').addEventListener('click', start);
+  $('#stopBtn').addEventListener('click', stop);
+  $('#zoomSlider').addEventListener('input', e => applyZoom(e.target.value));
+  $('#z1').addEventListener('click', ()=>applyZoom(1));
+  $('#z2').addEventListener('click', ()=>applyZoom(2));
+  $('#stabilizeBtn').addEventListener('click', stabilize);
 
   // Emulated 2×: force 1× live preview, then crop center when capturing
-  els.capEmu.addEventListener('click', async() => {
+  $('#capEmu').addEventListener('click', async() => {
     await applyZoom(1);
     await stabilize();
-    await capture(els.c1, { emulatedCrop: true });
-    analyze(els.c1, els.h1, els.s1);
-    els.dl1.disabled = false;
+    await capture($('#c1'), { emulatedCrop: true });
+    analyze($('#c1'), $('#h1'), $('#s1'));
+    $('#dl1').disabled = false;
   });
 
   // Real 2×: request camera zoom=2; if unsupported, we fall back to crop and label it
-  els.capReal.addEventListener('click', async () => {
+  $('#capReal').addEventListener('click', async () => {
     const realSupported = !usingEmulatedZoom; // if live zoom is emulated, we can't do real
     if (!realSupported) {
       alert('Native camera zoom is not available in this browser. Falling back to an emulated 2× crop for the "Real" capture.');
     }
     await applyZoom(2);
     await stabilize();
-    await capture(els.c2, { emulatedCrop: !realSupported });
-    analyze(els.c2, els.h2, els.s2);
-    els.dl2.disabled = true;
-    els.dl2.disabled = false;
+    await capture($('#c2'), { emulatedCrop: !realSupported });
+    analyze($('#c2'), $('#h2'), $('#s2'));
+    $('#dl2').disabled = true;
+    $('#dl2').disabled = false;
   });
 
-  els.dl1.addEventListener('click', ()=>download(els.c1, 'capture-emulated-2x.png'));
-  els.dl2.addEventListener('click', ()=>download(els.c2, 'capture-real-2x.png'));
+  $('#dl1').addEventListener('click', ()=>download($('#c1'), 'capture-emulated-2x.png'));
+  $('#dl2').addEventListener('click', ()=>download($('#c2'), 'capture-real-2x.png'));
 
-  document.getElementById('resetBtn').addEventListener('click', ()=>{
-    [els.c1,els.c2].forEach(c=>{c.width=0;c.height=0;});
-    [els.h1,els.h2].forEach(h=>{const x=h.getContext('2d'); x.clearRect(0,0,h.width,h.height)});
-    els.s1.textContent='—'; els.s2.textContent='—';
-    els.dl1.disabled = true; els.dl2.disabled = true;
+  $('#resetBtn').addEventListener('click', ()=>{
+    [$('#c1'),$('#c2')].forEach(c=>{c.width=0;c.height=0;});
+    [$('#h1'),$('#h2')].forEach(h=>{const x=h.getContext('2d'); x.clearRect(0,0,h.width,h.height)});
+    $('#s1').textContent='—'; $('#s2').textContent='—';
+    $('#dl1').disabled = true; $('#dl2').disabled = true;
   });
 
   // Torch toggle if supported
-  els.torch.addEventListener('click', async()=>{
+  $('#torchBtn').addEventListener('click', async()=>{
     if (!track) return;
     try{
       const caps = track.getCapabilities?.() || {};
@@ -406,9 +380,9 @@
     }catch(e){ console.warn('Torch toggle failed', e); }
   });
 
-  els.zSlider.addEventListener('input', ()=>{
-    const z = parseFloat(els.zSlider.value);
-    els.zRead.textContent = `${z.toFixed(2)}×${usingEmulatedZoom?' (emulated)':''}`;
+  $('#zoomSlider').addEventListener('input', ()=>{
+    const z = parseFloat($('#zoomSlider').value);
+    $('#zoomRead').textContent = `${z.toFixed(2)}×${usingEmulatedZoom?' (emulated)':''}`;
   });
 })();
 </script>


### PR DESCRIPTION
## Summary
- Use `$` helper for direct DOM access across modules
- Remove redundant element caches in UI scripts
- Revert earlier DOM helper changes to `game-engine.js`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b76a795600832c87032553223cfc10