### PR TITLE
refactor: centralize camera zoom and resolution

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,8 +257,6 @@ const Controller = (() => {
   async function start() {
     Setup.bind();
     if (!await Feeds.init()) return;
-    const cfg = Config.get();
-    Setup.updateFrontCrop();
     if (!await Detect.init()) return;
     lastTop = 0;
     if (isMjpeg()) {


### PR DESCRIPTION
## Summary
- restore original getUserMedia constraints with environment facing mode and 60 fps
- compute cropped canvas sizes from camW/camH/zoom and set defaults to 1920×1080
- remove obsolete front crop updater call

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b88b514648832c8393639c87a63683