### PR TITLE
refactor: drop unused feeds script and preview view

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -72,13 +72,13 @@ const PreviewGfx = (() => {
     ctxFront2d.fill();
   }
 
-  function view(device, which) {
-    ensureGPU(device);
-    const ctx = which === 'front' ? ctxFrontGPU : ctxTopGPU;
-    return ctx ? ctx.getCurrentTexture().createView() : null;
-  }
+  // function view(device, which) {
+  //   ensureGPU(device);
+  //   const ctx = which === 'front' ? ctxFrontGPU : ctxTopGPU;
+  //   return ctx ? ctx.getCurrentTexture().createView() : null;
+  // }
 
-  return { view, drawRect, drawHit, clear };
+  return { /*view,*/ drawRect, drawHit, clear };
 })();
 
 

--- a/app/feeds.js
+++ b/app/feeds.js
@@ -3,7 +3,7 @@
 
   const Feeds = (() => {
     let Config, cfg;
-    let videoTop, track, dc, videoWorker;
+    let videoTop, track, videoWorker;
     let lastFrame;
 
     function startVideoWorker(track, onFrame) {
@@ -62,8 +62,7 @@
       try {
         ctrl = await RTC.startB({
           log,
-          onOpen: (ch) => {
-            dc = ch;
+          onOpen: () => {
             log('connected');
           },
           onMessage: (data) => {
@@ -76,8 +75,6 @@
         return false;
       }
       if (!ctrl?.pc) { log('no offer found — open A first'); return false; }
-
-      window.sendBit = bit => { if (dc?.readyState === 'open') dc.send(bit); };
       return true;
     }
 

--- a/top.html
+++ b/top.html
@@ -117,7 +117,6 @@
   <script src="app/webrtc.js"></script>
   <script src="app/config.js"></script>
   <script src="app/detect.js"></script>
-  <script src="app/feeds.js"></script>
   <script src="app/setup.js"></script>
   <script src="app/top.js"></script>
 


### PR DESCRIPTION
## Summary
- remove app/feeds.js from top.html
- drop sendBit and data channel usage from Feeds
- comment out unused PreviewGfx.view helper

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8aef14058832c9457d2f1b2d96d63