### PR TITLE
refactor: isolate sendBit and restore feeds script

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -72,13 +72,13 @@ const PreviewGfx = (() => {
     ctxFront2d.fill();
   }
 
-  function view(device, which) {
-    ensureGPU(device);
-    const ctx = which === 'front' ? ctxFrontGPU : ctxTopGPU;
-    return ctx ? ctx.getCurrentTexture().createView() : null;
-  }
+  // function view(device, which) {
+  //   ensureGPU(device);
+  //   const ctx = which === 'front' ? ctxFrontGPU : ctxTopGPU;
+  //   return ctx ? ctx.getCurrentTexture().createView() : null;
+  // }
 
-  return { view, drawRect, drawHit, clear };
+  return { /*view,*/ drawRect, drawHit, clear };
 })();
 
 

--- a/app/feeds.js
+++ b/app/feeds.js
@@ -76,8 +76,6 @@
         return false;
       }
       if (!ctrl?.pc) { log('no offer found — open A first'); return false; }
-
-      window.sendBit = bit => { if (dc?.readyState === 'open') dc.send(bit); };
       return true;
     }
 


### PR DESCRIPTION
## Summary
- load app/feeds.js again on the top page
- keep `sendBit` defined only in `top.js`; `feeds.js` remains for incoming bits
- comment out unused `PreviewGfx.view` helper

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8aef14058832c9457d2f1b2d96d63