### PR TITLE
Remove redundant Setup binding calls

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -255,7 +255,6 @@ const Controller = (() => {
   }
 
   async function start() {
-    Setup.bind();
     if (!await Feeds.init()) return;
     if (!await Detect.init()) return;
     lastTop = 0;

--- a/app/setup.js
+++ b/app/setup.js
@@ -486,9 +486,5 @@
   })();
 
   window.Setup = Setup;
-  if (document.readyState !== 'loading') {
-    Setup.bind();
-  } else {
-    window.addEventListener('DOMContentLoaded', () => Setup.bind(), { once: true });
-  }
+  Setup.bind();
 })();

--- a/app/top.js
+++ b/app/top.js
@@ -34,7 +34,6 @@
     }
 
     function start() {
-      Setup.bind();
       wireStartA();
     }
 


### PR DESCRIPTION
## Summary
- Let Setup self-initialize by invoking `Setup.bind()` internally
- Restore direct `Controller.start()` invocation without DOM readiness check

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8af43990c832ca93bd64873aa3f85