### PR TITLE
feat: add top camera detection

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -3,6 +3,7 @@
 
   const Controller = (() => {
     let dc;
+    let running = false;
 
     function handleOpen() {
       $('#state').textContent = 'Connected';
@@ -33,15 +34,81 @@
       }
     }
 
+    async function startDetection() {
+      if (running) return;
+      running = true;
+      const cfg = window.Config?.get?.() || {};
+      const TEAM_INDICES = window.TEAM_INDICES || {};
+
+      if (!await Feeds.init()) {
+        if ($('#info')) $('#info').textContent = 'Feed init failed';
+        running = false;
+        return;
+      }
+
+      const colorA = TEAM_INDICES[cfg.teamA];
+      const colorB = TEAM_INDICES[cfg.teamB];
+      const canvas = $('#gfx');
+      let infoBase = '';
+
+      while (running) {
+        const frame = await Feeds.frontFrame();
+        if (!frame) { await new Promise(r => setTimeout(r, 0)); continue; }
+        try {
+          const cropW = frame.displayWidth || frame.codedWidth;
+          const cropH = frame.displayHeight || frame.codedHeight;
+          const rect = cfg.topRect || { x: 0, y: 0, w: cropW, h: cropH };
+          const { a, b, w, h, resized } = await GPU.detect({
+            key: 'top',
+            source: frame,
+            colorA,
+            colorB,
+            domThrA: cfg.domThr[colorA],
+            satMinA: cfg.satMin[colorA],
+            yMinA: cfg.yMin[colorA],
+            yMaxA: cfg.yMax[colorA],
+            domThrB: cfg.domThr[colorB],
+            satMinB: cfg.satMin[colorB],
+            yMinB: cfg.yMin[colorB],
+            yMaxB: cfg.yMax[colorB],
+            rect: { min: new Float32Array([rect.x, rect.y]), max: new Float32Array([rect.x + rect.w, rect.y + rect.h]) },
+            previewCanvas: canvas,
+            preview: true,
+            activeA: true,
+            activeB: true,
+            flipY: true,
+            radiusPx: cfg.radiusPx,
+          });
+          if (resized) {
+            canvas.width = cropW;
+            canvas.height = cropH;
+            infoBase = `Running ${w}×${h}, shader.wgsl compute+render (VideoFrame).`;
+            if ($('#info')) $('#info').textContent = infoBase;
+          }
+          const scoreA = (a[0] >>> 16) / 65535;
+          const scoreB = (b[0] >>> 16) / 65535;
+          const onA = scoreA >= cfg.topMinArea;
+          const onB = scoreB >= cfg.topMinArea;
+          if (onA || onB) {
+            const bit = onA && onB ? '2' : onA ? '0' : '1';
+            sendBit(bit);
+          }
+        } catch (err) {
+          if ($('#info')) $('#info').textContent = (err && err.message) ? err.message : String(err);
+          console.error(err);
+        } finally {
+          frame.close();
+        }
+      }
+    }
+
     function start() {
-      Setup.bind();
       wireStartA();
     }
 
-    return { start, sendBit };
+    return { start, sendBit, startDetection };
   })();
 
-  window.Top = { Controller };
-  window.sendBit = Controller.sendBit;
-  window.addEventListener('load', () => Controller.start());
+  window.Controller = Controller;
+  Controller.start();
 })();


### PR DESCRIPTION
## Summary
- Implement top camera detection loop in controller using `Feeds` and `GPU.detect`
- Relay team presence bits over WebRTC and render mask preview to canvas
- Start detection pipeline from setup start button
- Expose `Controller` globally and remove global `sendbit` alias, using `Controller.sendBit` instead

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8b228f4f0832caa429aec9cc55da6