### PR TITLE
Fix optional chaining error in feeds initialization

### DIFF
--- a/app/feeds.js
+++ b/app/feeds.js
@@ -96,7 +96,7 @@
           try {
             await videoTop.decode();
           } catch (err) {
-            $('#urlWarn')?.textContent = '⚠️';
+            if ($('#urlWarn')) $('#urlWarn').textContent = '⚠️';
             console.log('Failed to load top camera feed', err);
             return false;
           }


### PR DESCRIPTION
## Summary
- handle missing top camera feed URL without invalid assignment
- inline url warning element lookup in error handler

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b921ff9930832cb091825c17a99eb8