### PR TITLE
fix: expose preview flag in top controller

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -110,5 +110,6 @@
   })();
 
   Controller.start();
-  window.Controller = { startDetection: Controller.startDetection };
+  // Always expose `isPreview` so configuration overlays remain active.
+  window.Controller = { startDetection: Controller.startDetection, isPreview: true };
 })();


### PR DESCRIPTION
## Summary
- ensure top controller exposes `isPreview` flag as always on

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc58cb4168832c9fb8f630bb6906f8