### PR TITLE
fix: default top ROI and expose preview flag

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -57,7 +57,10 @@
         try {
           const cropW = frame.displayWidth || frame.codedWidth;
           const cropH = frame.displayHeight || frame.codedHeight;
-          const rect = cfg.topRect || { x: 0, y: 0, w: cropW, h: cropH };
+          const rectCfg = cfg.topRect;
+          const rect = (rectCfg && rectCfg.w > 0 && rectCfg.h > 0)
+            ? rectCfg
+            : { x: 0, y: 0, w: cropW, h: cropH };
           const { a, b, w, h, resized } = await GPU.detect({
             key: 'top',
             source: frame,
@@ -106,9 +109,9 @@
       wireStartA();
     }
 
-    return { start, sendBit, startDetection };
+  return { start, sendBit, startDetection };
   })();
 
   Controller.start();
-  window.Controller = { startDetection: Controller.startDetection };
+  window.Controller = { startDetection: Controller.startDetection, isPreview: true };
 })();


### PR DESCRIPTION
## Summary
- fall back to full-frame region if topRect is unset so mask overlay renders
- expose `isPreview` on the top controller to allow configuration overlays

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc58cb4168832c9fb8f630bb6906f8