### PR TITLE
Use full frame for empty top region

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -18,9 +18,9 @@
     yMax: Array(4).fill(0.70),
     radiusPx: 18,
     url: 'http://192.168.43.1:8080/video',
-    topRect: { x: 0, y: 0, w: 0, h: 0 },
+    topRect: { x: 0, y: 0, w: 1920, h: 1080 },
     frontRect: { x: 0, y: 0, w: 0, h: 0 },
-    topH: 160,
+    topH: 1080,
     frontH: 220,
     topMode: 0,
     COLOR_TABLE: [

--- a/app/top.js
+++ b/app/top.js
@@ -57,7 +57,10 @@
         try {
           const cropW = frame.displayWidth || frame.codedWidth;
           const cropH = frame.displayHeight || frame.codedHeight;
-          const rect = cfg.topRect || { x: 0, y: 0, w: cropW, h: cropH };
+          const rectCfg = cfg.topRect;
+          const rect = (rectCfg && rectCfg.w > 0 && rectCfg.h > 0)
+            ? rectCfg
+            : { x: 0, y: 0, w: cropW, h: cropH };
           const { a, b, w, h, resized } = await GPU.detect({
             key: 'top',
             source: frame,


### PR DESCRIPTION
## Summary
- Avoid disabling mask rendering when the configured top region has zero size by falling back to the full frame
- Default top detection region to full-frame dimensions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd23045498832cb1477dca697d796e