### PR TITLE
Init WebRTC per page

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -210,6 +210,7 @@ const Controller = (() => {
   let lastTop = 0;
   const Controller = { isPreview: false };
 
+
   async function topLoop(ts) {
     if (ts - lastTop < TOP_INTERVAL) {
       requestAnimationFrame(topLoop);
@@ -255,6 +256,9 @@ const Controller = (() => {
   }
 
   async function start() {
+    if (Config.get().topMode === 0) {
+      RTC.startB();
+    }
     if (!await Feeds.init()) return;
     if (!await Detect.init()) return;
     lastTop = 0;

--- a/app/top.js
+++ b/app/top.js
@@ -2,37 +2,7 @@
   'use strict';
 
   const Controller = (() => {
-    let dc;
     let running = false;
-
-    function handleOpen() {
-      $('#state').textContent = 'Connected';
-      $('#b0').disabled = false;
-      $('#b0').onclick = () => sendBit('0');
-    }
-
-    function wireStartA() {
-      const log = msg => $('#state') && ($('#state').textContent = String(msg));
-      RTC.startA({
-        log,
-        onOpen: (ch) => {
-          dc = ch;
-          handleOpen();
-        },
-        onMessage: (data) => {
-          console.log('msg:', data);
-        }
-      }).catch(err => {
-        log('ERR: ' + (err && (err.stack || err)));
-      });
-    }
-
-    function sendBit(bit) {
-      if (dc && dc.readyState === 'open') {
-        dc.send(bit);
-        console.log(`[${new Date().toISOString()}] sent hit ${bit}`);
-      }
-    }
 
     async function startDetection() {
       if (running) return;
@@ -94,7 +64,7 @@
           const onB = scoreB >= cfg.topMinArea;
           if (onA || onB) {
             const bit = onA && onB ? '2' : onA ? '0' : '1';
-            sendBit(bit);
+            RTC.send(bit);
           }
         } catch (err) {
           if ($('#info')) $('#info').textContent = (err && err.message) ? err.message : String(err);
@@ -106,10 +76,10 @@
     }
 
     function start() {
-      wireStartA();
+      RTC.startA();
     }
 
-    return { start, sendBit, startDetection };
+    return { start, startDetection };
   })();
 
   Controller.start();


### PR DESCRIPTION
## Summary
- Inline WebRTC startup so `RTC.startA()` and `RTC.startB()` handle their own logging and callbacks
- Simplify pages to call the appropriate startup method and send bits via a shared `RTC.send`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c185fa7ad8832c92a1726af1026cef