### PR TITLE
feat: conditionally rotate canvas when video frame is landscape

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -20,6 +20,7 @@
       const colorB = TEAM_INDICES[cfg.teamB];
       const canvas = $('#gfx');
       let infoBase = '';
+      let rotationSet = false;
 
       while (running) {
         const frame = await Feeds.frontFrame();
@@ -27,6 +28,10 @@
         try {
           const cropW = frame.displayWidth || frame.codedWidth;
           const cropH = frame.displayHeight || frame.codedHeight;
+          if (!rotationSet) {
+            canvas.classList.toggle('rotate', cropW > cropH);
+            rotationSet = true;
+          }
           const rectCfg = cfg.topRect;
           const rect = (rectCfg && rectCfg.w > 0 && rectCfg.h > 0)
             ? rectCfg

--- a/top.html
+++ b/top.html
@@ -40,7 +40,7 @@
 
     /* PORTRAIT: rotate and instead fill height, cap by width — preserves ratio */
     @media (orientation: portrait) {
-      #gfx {
+      #gfx.rotate {
         transform: translate(-50%, -50%) rotate(90deg);
         width: 100dvh;
         /* 👈 swap */


### PR DESCRIPTION
## Summary
- add `rotate` class styling so portrait rotation is only applied when needed
- toggle the rotation class once based on the first camera frame's aspect ratio

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c488016f54832c96fa857b214fa114