### PR TITLE
Fix FPS measurement to count only processed frames

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -32,6 +32,9 @@
       };
 
       while (running) {
+        const frame = await Feeds.frontFrame();
+        if (!frame) { await new Promise(r => setTimeout(r, 0)); continue; }
+
         const loopStart = performance.now();
         total += loopStart - lastStart;
         frames++;
@@ -45,9 +48,6 @@
           lastReport = loopStart;
         }
         lastStart = loopStart;
-
-        const frame = await Feeds.frontFrame();
-        if (!frame) { await new Promise(r => setTimeout(r, 0)); continue; }
         try {
           const cropW = frame.displayWidth || frame.codedWidth;
           const cropH = frame.displayHeight || frame.codedHeight;


### PR DESCRIPTION
## Summary
- compute frame rate only after a frame is received to avoid inflated FPS readings

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c490773fb0832cac541cf82c3245d8