### PR TITLE
Remove vertical flip and set top camera to user-facing

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -135,8 +135,7 @@ const Detect = (() => {
         previewCanvas: preview ? $('#topTex') : null,
       preview,
       activeA: true,
-      activeB: true,
-      flipY: true
+      activeB: true
     });
     // a[0]/b[0] are Best.key (Q16 score in high 16 bits)
     const scoreA = (a[0] >>> 16) / 65535;
@@ -174,8 +173,7 @@ const Detect = (() => {
           previewCanvas: preview ? $('#frontTex') : null,
         preview,
         activeA: aActive,
-        activeB: bActive,
-        flipY: true
+        activeB: bActive
       });
         if (resized && $('#frontTex')) {
           $('#frontTex').width = frame.displayWidth;

--- a/app/detect.js
+++ b/app/detect.js
@@ -224,7 +224,7 @@
     preview = false,
     activeA = true,
     activeB = true,
-    flipY = true,
+    flipY = false,
     // Calibration knobs for the new WGSL:
     colorA = 0,           // 0=R,1=G,2=B,3=Y
     colorB = 2,

--- a/app/feeds.js
+++ b/app/feeds.js
@@ -62,7 +62,7 @@ self.onmessage = async ({ data }) => {
       return new VideoFrame(frame, { visibleRect: { x, y, width: cropW, height: cropH } });
     }
 
-    async function init() {
+    async function init({ facingMode = 'environment' } = {}) {
       if (!window.Config) return false;
       Config = window.Config;
       cfg = Config.get();
@@ -95,7 +95,7 @@ self.onmessage = async ({ data }) => {
           video: {
             width: { ideal: reqW },
             height: { ideal: reqH },
-            facingMode: 'environment',
+            facingMode,
             frameRate: { ideal: 60 }
           }
         });

--- a/app/shader.wgsl
+++ b/app/shader.wgsl
@@ -421,9 +421,9 @@ fn vs(@builtin(vertex_index) vi : u32) -> VSOut {
     vec2<f32>(-1.0,  3.0)
   );
   var uv = array<vec2<f32>, 3>(
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(2.0, 1.0),
-    vec2<f32>(0.0, -1.0)
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(2.0, 0.0),
+    vec2<f32>(0.0, 2.0)
   );
   var o: VSOut;
   o.pos = vec4<f32>(p[vi], 0.0, 1.0);

--- a/app/shader_f32.wgsl
+++ b/app/shader_f32.wgsl
@@ -418,9 +418,9 @@ fn vs(@builtin(vertex_index) vi : u32) -> VSOut {
     vec2<f32>(-1.0,  3.0)
   );
   var uv = array<vec2<f32>, 3>(
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(2.0, 1.0),
-    vec2<f32>(0.0, -1.0)
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(2.0, 0.0),
+    vec2<f32>(0.0, 2.0)
   );
   var o: VSOut;
   o.pos = vec4<f32>(p[vi], 0.0, 1.0);

--- a/app/top.js
+++ b/app/top.js
@@ -11,7 +11,7 @@
       const TEAM_INDICES = window.TEAM_INDICES || {};
       const infoEl = $('#info');
 
-      if (!await Feeds.init()) {
+      if (!await Feeds.init({ facingMode: 'user' })) {
         if (infoEl) infoEl.textContent = 'Feed init failed';
         running = false;
         return;
@@ -77,7 +77,6 @@
             preview: true,
             activeA: true,
             activeB: true,
-            flipY: true,
             radiusPx: cfg.radiusPx,
           });
           if (resized) {


### PR DESCRIPTION
## Summary
- eliminate vertical flipping from GPU detection and shaders
- allow choosing camera orientation and use the user-facing camera in top.html

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6cdb32e40832cac8aa60d94b369b6