### PR TITLE
Fix vertical orientation of camera frames

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -135,7 +135,8 @@ const Detect = (() => {
         previewCanvas: preview ? $('#topTex') : null,
       preview,
       activeA: true,
-      activeB: true
+      activeB: true,
+      flipY: true
     });
     // a[0]/b[0] are Best.key (Q16 score in high 16 bits)
     const scoreA = (a[0] >>> 16) / 65535;
@@ -173,7 +174,8 @@ const Detect = (() => {
           previewCanvas: preview ? $('#frontTex') : null,
         preview,
         activeA: aActive,
-        activeB: bActive
+        activeB: bActive,
+        flipY: true
       });
         if (resized && $('#frontTex')) {
           $('#frontTex').width = frame.displayWidth;

--- a/app/detect.js
+++ b/app/detect.js
@@ -224,7 +224,7 @@
     preview = false,
     activeA = true,
     activeB = true,
-    flipY = false,
+    flipY = true,
     // Calibration knobs for the new WGSL:
     colorA = 0,           // 0=R,1=G,2=B,3=Y
     colorB = 2,

--- a/app/top.js
+++ b/app/top.js
@@ -77,6 +77,7 @@
             preview: true,
             activeA: true,
             activeB: true,
+            flipY: true,
             radiusPx: cfg.radiusPx,
           });
           if (resized) {


### PR DESCRIPTION
## Summary
- Restore default vertical flip when copying camera frames to textures
- Explicitly request vertical flipping in all detection calls to keep video upright

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d5a87f48832c99170adebef1540b