### PR TITLE
Simplify camera resolution handling

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -141,6 +141,7 @@
         $('#camW').addEventListener('change', e => {
           cfg.camW = u.toEvenInt(u.clamp(Number(e.target.value) || 0, 2, Number.MAX_SAFE_INTEGER));
           Config.save('camW', cfg.camW);
+          e.target.value = cfg.camW;
           recomputeSizes();
         });
       }
@@ -149,6 +150,7 @@
         $('#camH').addEventListener('change', e => {
           cfg.camH = u.toEvenInt(u.clamp(Number(e.target.value) || 0, 2, Number.MAX_SAFE_INTEGER));
           Config.save('camH', cfg.camH);
+          e.target.value = cfg.camH;
           recomputeSizes();
         });
       }

--- a/top.html
+++ b/top.html
@@ -81,6 +81,9 @@
     <fieldset>
       <button id="start">Start</button>
       <input id="zoom" type="number" placeholder="zoom" step="0.01" min="1" value="1" />
+      <input id="camW" type="number" placeholder="width" min="2" step="2" value="1920" />
+      ×
+      <input id="camH" type="number" placeholder="height" min="2" step="2" value="1080" />
     </fieldset>
     <fieldset>
       <select id="teamA">


### PR DESCRIPTION
## Summary
- move the camera width and height inputs into the same fieldset as the start controls so they sit together without extra labeling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cab67f3808832ca43a0fd95cea645a