### PR TITLE
Add cached runtime view for config values

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -6,6 +6,46 @@
 
   window.createConfig = function createConfig(defaults) {
     let cfg;
+    // --- Internal cached "runtime view" ---
+    let _cached = null;
+
+    // Helpers
+    const asNum = (v) => (typeof v === 'string' ? +v : v);
+    const f32 = (a) => Float32Array.from(a || [], asNum);
+    const rectMM = (r) => {
+      if (!r) {
+        return { min: new Float32Array([0, 0]), max: new Float32Array([0, 0]) };
+      }
+      const x0 = asNum(r.x);
+      const y0 = asNum(r.y);
+      const x1 = x0 + asNum(r.w);
+      const y1 = y0 + asNum(r.h);
+      return { min: new Float32Array([x0, y0]), max: new Float32Array([x1, y1]) };
+    };
+
+    function buildCache() {
+      // Start from the stored cfg and produce a runtime-friendly view.
+      const view = Object.assign({}, cfg);
+      // Precompute numeric/typed versions used by detection (same property names kept)
+      view.domThr = f32(cfg.domThr);
+      view.satMin = f32(cfg.satMin);
+      view.yMin = f32(cfg.yMin);
+      view.yMax = f32(cfg.yMax);
+      // Add precomputed color indices & min/max rects (non-breaking: extra fields)
+      view.colorA = TEAM_INDICES[cfg.teamA];
+      view.colorB = TEAM_INDICES[cfg.teamB];
+      view.topRectMM = rectMM(cfg.topRect);
+      view.frontRectMM = rectMM(cfg.frontRect);
+      return view;
+    }
+
+    function rebuildCache() {
+      if (!cfg) {
+        _cached = null;
+        return;
+      }
+      _cached = buildCache();
+    }
 
     function load(opts = {}) {
       cfg = {};
@@ -25,6 +65,8 @@
         }
       }
 
+      rebuildCache();
+
       return cfg;
     }
 
@@ -32,11 +74,22 @@
       localStorage.setItem(name, JSON.stringify(value));
       if (cfg) {
         cfg[name] = value;
+        // Any persisted change may affect detection; keep cache hot & ready.
+        rebuildCache();
+      } else {
+        _cached = null;
       }
     }
 
     function get() {
-      return cfg;
+      // Always return the cached, detection-ready view when available.
+      if (!_cached) {
+        if (!cfg) {
+          return cfg;
+        }
+        _cached = buildCache();
+      }
+      return _cached;
     }
 
     return { load, save, get };


### PR DESCRIPTION
## Summary
- add helper functions and runtime cache for config values to provide detection-ready views
- precompute typed arrays and team color indices for faster access and add rectangle min/max helpers
- ensure cache rebuilds on load/save while preserving existing optional f16 range setup

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdba1af4ec832cb53208c348aa10eb