### PR TITLE
Update top detection config usage

### DIFF
--- a/app/top.js
+++ b/app/top.js
@@ -7,7 +7,7 @@
     async function startDetection() {
       if (running) return;
       running = true;
-      const TEAM_INDICES = window.TEAM_INDICES || {};
+      const TEAM_INDICES = window.TEAM_INDICES;
       const infoEl = $('#info');
 
       if (!await Feeds.init({ facingMode: 'user' })) {
@@ -53,8 +53,8 @@
             rotationSet = true;
           }
           const cfg = window.Config.get();
-          const colorA = cfg.colorA ?? TEAM_INDICES[cfg.teamA];
-          const colorB = cfg.colorB ?? TEAM_INDICES[cfg.teamB];
+          const colorA = cfg.colorA;
+          const colorB = cfg.colorB;
           const { a, b, w, h, resized } = await GPU.detect({
             key: 'top',
             source: frame,
@@ -74,6 +74,7 @@
             activeB: true,
             flipY: true,
             radiusPx: cfg.radiusPx,
+            rect: null
           });
           if (resized) {
             canvas.width = cropW;


### PR DESCRIPTION
## Summary
- stop defaulting TEAM_INDICES to an empty object and rely on configured values
- always use configured colors for detection instead of falling back to team indices
- explicitly pass a null rect to GPU.detect to align with expected parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce868b958c832c81fbf41beaf13ab5