### PR TITLE
Gate preview rendering behind flag

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -45,6 +45,7 @@ const PreviewGfx = (() => {
   }
 
   function drawRect(rect, color, which) {
+    if (!window.Controller?.isPreview) return;
     ensure2d();
     const ctx = which === 'front' ? ctxFront2d : ctxTop2d;
     if (!ctx) return;
@@ -59,6 +60,7 @@ const PreviewGfx = (() => {
   }
 
   function drawHit(hit) {
+    if (!window.Controller?.isPreview) return;
     ensure2d();
     if (!ctxFront2d) return;
     const { frontResW, frontResH } = Config.get();
@@ -249,11 +251,7 @@ const Controller = (() => {
   Controller.handleBit = handleBit;
   return Controller;
 })();
-window.PreviewGfx = { drawRect: PreviewGfx.drawRect };
-window.Controller = {
-  handleBit: Controller.handleBit,
-  get isPreview() { return Controller.isPreview; },
-  set isPreview(v) { Controller.isPreview = v; }
-};
+window.PreviewGfx = { drawRect: PreviewGfx.drawRect, clear: PreviewGfx.clear };
+window.Controller = Controller;
 Controller.start();
 })();

--- a/app/detect.js
+++ b/app/detect.js
@@ -307,7 +307,9 @@
 
     const enc = device.createCommandEncoder();
     // (Optional) clear preview target if you use it
-    enc.beginRenderPass({ colorAttachments: [{ view: ctx.feed.maskView, loadOp: 'clear', storeOp: 'store' }] }).end();
+    if (preview) {
+      enc.beginRenderPass({ colorAttachments: [{ view: ctx.feed.maskView, loadOp: 'clear', storeOp: 'store' }] }).end();
+    }
 
     // Pass 1: sparse grid seed
     const seedPass = enc.beginComputePass({ label: 'detect:seed_grid' });
@@ -335,7 +337,7 @@
     enc.copyBufferToBuffer(ctx.pack.bestA, 0, ctx.pack.readA, 0, 12);
     enc.copyBufferToBuffer(ctx.pack.bestB, 0, ctx.pack.readB, 0, 12);
 
-    if (view && state.pipelines.render) {
+    if (preview && view && state.pipelines.render) {
       const r = enc.beginRenderPass({ colorAttachments: [{ view, loadOp: 'clear', storeOp: 'store' }] });
       r.setPipeline(state.pipelines.render);
       r.setBindGroup(0, ctx.feed.getRenderBG(ctx.pack));


### PR DESCRIPTION
## Summary
- ensure overlay drawing routines bail out unless preview mode is enabled by checking `Controller.isPreview` directly
- only clear and render the GPU mask textures when preview output is requested
- expose the controller object directly on `window` so screen navigation can toggle preview state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfe3646074832cb84af37dd4d6e8c6