### PR TITLE
Refine config access patterns

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,8 +7,7 @@
 (function () {
   'use strict';
 
-  const Config = window.Config;
-const PreviewGfx = (() => {
+  const PreviewGfx = (() => {
   let ctxTop2d, ctxFront2d, ctxTopGPU, ctxFrontGPU;
 
   function ensure2d() {
@@ -63,7 +62,9 @@ const PreviewGfx = (() => {
     if (!window.Controller?.isPreview) return;
     ensure2d();
     if (!ctxFront2d) return;
-    const { frontResW, frontResH } = Config.get();
+    const cfg = window.cfg;
+    if (!cfg) return;
+    const { frontResW, frontResH } = cfg;
     ctxFront2d.fillStyle = hit.team;
     const px = hit.x * frontResW, py = hit.y * frontResH;
     ctxFront2d.beginPath();
@@ -81,7 +82,7 @@ const PreviewGfx = (() => {
 })();
 
 
-const Detect = (() => {
+  const Detect = (() => {
 
   async function init() {
     // all GPU checks/device creation removed
@@ -89,7 +90,8 @@ const Detect = (() => {
     return true;
   }
   async function runTopDetection(preview) {
-    const cfg = Config.get();
+    const cfg = window.cfg;
+    if (!cfg) return { presentA: false, presentB: false, scoreA: 0, scoreB: 0 };
     const colorA = cfg.colorA;
     const colorB = cfg.colorB;
     const { a, b } = await GPU.detect({
@@ -98,14 +100,14 @@ const Detect = (() => {
       colorA,
       colorB,
       refine: false,
-      domThrA: cfg.domThr[colorA],
-      satMinA: cfg.satMin[colorA],
-      yMinA: cfg.yMin[colorA],
-      yMaxA: cfg.yMax[colorA],
-      domThrB: cfg.domThr[colorB],
-      satMinB: cfg.satMin[colorB],
-      yMinB: cfg.yMin[colorB],
-      yMaxB: cfg.yMax[colorB],
+      domThrA: cfg.domThrA,
+      satMinA: cfg.satMinA,
+      yMinA: cfg.yMinA,
+      yMaxA: cfg.yMaxA,
+      domThrB: cfg.domThrB,
+      satMinB: cfg.satMinB,
+      yMinB: cfg.yMinB,
+      yMaxB: cfg.yMaxB,
       radiusPx: cfg.radiusPx,
       rect: cfg.topRectMM,   // may be null -> full-frame inside detect.js
       previewCanvas: preview ? $('#topTex') : null,
@@ -117,20 +119,21 @@ const Detect = (() => {
     // a[0]/b[0] are Best.key (Q16 score in high 16 bits)
     const scoreA = (a[0] >>> 16) / 65535;
     const scoreB = (b[0] >>> 16) / 65535;
-    const presentA = scoreA >= Config.get().topMinArea;
-    const presentB = scoreB >= Config.get().topMinArea;
+    const presentA = scoreA >= cfg.topMinArea;
+    const presentB = scoreB >= cfg.topMinArea;
     return { presentA, presentB, scoreA, scoreB };
   }
 
   let frontRunning = false;
   async function runFrontDetection(aActive, bActive, preview) {
     if (frontRunning) return { detected: false, hits: [] };
+    const cfg = window.cfg;
+    if (!cfg) return { detected: false, hits: [] };
     frontRunning = true;
     let frame;
     try {
       frame = await Feeds.frontFrame();
       if (!frame) return { detected: false, hits: [] };
-      const cfg = Config.get();
       const colorA = cfg.colorA;
       const colorB = cfg.colorB;
       const { a, b, w, h, resized } = await GPU.detect({
@@ -139,14 +142,14 @@ const Detect = (() => {
         colorA,
         colorB,
         refine: true,
-        domThrA: cfg.domThr[colorA],
-        satMinA: cfg.satMin[colorA],
-        yMinA: cfg.yMin[colorA],
-        yMaxA: cfg.yMax[colorA],
-        domThrB: cfg.domThr[colorB],
-        satMinB: cfg.satMin[colorB],
-        yMinB: cfg.yMin[colorB],
-        yMaxB: cfg.yMax[colorB],
+        domThrA: cfg.domThrA,
+        satMinA: cfg.satMinA,
+        yMinA: cfg.yMinA,
+        yMaxA: cfg.yMaxA,
+        domThrB: cfg.domThrB,
+        satMinB: cfg.satMinB,
+        yMinB: cfg.yMinB,
+        yMaxB: cfg.yMaxB,
         radiusPx: cfg.radiusPx,
         rect: cfg.frontRectMM,  // may be null -> full-frame inside detect.js
         previewCanvas: preview ? $('#frontTex') : null,
@@ -163,11 +166,11 @@ const Detect = (() => {
       const [keyB, xB, yB] = b;
       const hits = [];
       if (aActive && keyA !== 0) {
-        const { teamA, frontResW, frontResH } = Config.get();
+        const { teamA, frontResW, frontResH } = cfg;
         hits.push({ team: teamA, x: xA / frontResW, y: yA / frontResH });
       }
       if (bActive && keyB !== 0) {
-        const { teamB, frontResW, frontResH } = Config.get();
+        const { teamB, frontResW, frontResH } = cfg;
         hits.push({ team: teamB, x: xB / frontResW, y: yB / frontResH });
       }
       if (preview && hits.length) {
@@ -183,12 +186,11 @@ const Detect = (() => {
   return { init, runTopDetection, runFrontDetection };
 })();
 
-const Controller = (() => {
-  const cfg = Config.get();
-  const TOP_FPS = 30;               // throttle only the MJPEG-top feed
-  const TOP_INTERVAL = 1000 / TOP_FPS;
-  let lastTop = 0;
-  const Controller = { isPreview: false };
+  const Controller = (() => {
+    const TOP_FPS = 30;               // throttle only the MJPEG-top feed
+    const TOP_INTERVAL = 1000 / TOP_FPS;
+    let lastTop = 0;
+    const Controller = { isPreview: false };
 
 
   async function topLoop(ts) {
@@ -236,13 +238,15 @@ const Controller = (() => {
   }
 
   async function start() {
-    if (Config.get().topMode === 0) {
+    const cfg = window.cfg;
+    if (!cfg) return;
+    if (cfg.topMode === 0) {
       RTC.startB();
     }
     if (!await Feeds.init()) return;
     if (!await Detect.init()) return;
     lastTop = 0;
-    if (Config.get().topMode === 1) {
+    if (cfg.topMode === 1) {
       requestAnimationFrame(topLoop);
     }
   }

--- a/app/feeds.js
+++ b/app/feeds.js
@@ -2,7 +2,7 @@
   'use strict';
 
   const Feeds = (() => {
-    let Config, cfg;
+    let Config;
     let videoTop, track, videoWorker;
     let lastFrame;
 
@@ -48,8 +48,8 @@ self.onmessage = async ({ data }) => {
     // Crop = Zoom (centered). Uses only Config.zoom (>= 1).
     function zoomFrame(frame) {
       const rect = frame.visibleRect || { x: 0, y: 0, width: frame.codedWidth, height: frame.codedHeight };
-      const conf = (Config?.get?.()) || cfg || {};
-      const zoom = u.clamp(Number(conf.zoom) || 1, 1, Number.POSITIVE_INFINITY);
+      const cfg = window.cfg;
+      const zoom = u.clamp(Number(cfg?.zoom) || 1, 1, Number.POSITIVE_INFINITY);
       // compute even crop size from current frame rect using zoom ratio
       let cropW = u.toEvenInt(rect.width  / zoom);
       let cropH = u.toEvenInt(rect.height / zoom);
@@ -65,7 +65,8 @@ self.onmessage = async ({ data }) => {
     async function init({ facingMode = 'environment' } = {}) {
       if (!window.Config) return false;
       Config = window.Config;
-      cfg = Config.get();
+      const cfg = window.cfg;
+      if (!cfg) return false;
 
       // Request resolution comes from config (single source of truth).
       const reqW = Number(cfg.camW) || 0;

--- a/app/setup.js
+++ b/app/setup.js
@@ -121,20 +121,18 @@
         const { createConfig } = window;
         Config = createConfig(DEFAULTS);
         Config.load();
-        cfg = Config.get();
+        cfg = window.cfg;
         for (const k of Object.keys(DEFAULTS)) {
           if (localStorage.getItem(k) === null) {
             Config.save(k, cfg[k]);
           }
         }
-        window.Config = { get: Config.get };
-      } else {
-        cfg = Config.get();
+        window.Config = Config;
       }
       // topMode should already be valid via defaults; do not coerce
       cfg.topMode = Number(cfg.topMode);
       Config.save('topMode', cfg.topMode);
-      // Arrays are already typed in Config.get() cache; do not re-type here
+      // Arrays are already typed in the cached config view; do not re-type here
       // Optional UI wiring (only stores values):
       // Zoom (single control or mirrored)
       $('#frontZoom')?.setAttribute('data-spinner', '');

--- a/app/top.js
+++ b/app/top.js
@@ -7,7 +7,6 @@
     async function startDetection() {
       if (running) return;
       running = true;
-      const TEAM_INDICES = window.TEAM_INDICES;
       const infoEl = $('#info');
 
       if (!await Feeds.init({ facingMode: 'user' })) {
@@ -31,6 +30,8 @@
       while (running) {
         const frame = await Feeds.frontFrame();
         if (!frame) { await new Promise(r => setTimeout(r, 0)); continue; }
+        const cfg = window.cfg;
+        if (!cfg) { frame.close(); continue; }
 
         const loopStart = performance.now();
         total += loopStart - lastStart;
@@ -52,7 +53,6 @@
             canvas.classList.toggle('rotate', cropW > cropH);
             rotationSet = true;
           }
-          const cfg = window.Config.get();
           const colorA = cfg.colorA;
           const colorB = cfg.colorB;
           const { a, b, w, h, resized } = await GPU.detect({
@@ -61,14 +61,14 @@
             colorA,
             colorB,
             refine: false,
-            domThrA: cfg.domThr[colorA],
-            satMinA: cfg.satMin[colorA],
-            yMinA: cfg.yMin[colorA],
-            yMaxA: cfg.yMax[colorA],
-            domThrB: cfg.domThr[colorB],
-            satMinB: cfg.satMin[colorB],
-            yMinB: cfg.yMin[colorB],
-            yMaxB: cfg.yMax[colorB],
+            domThrA: cfg.domThrA,
+            satMinA: cfg.satMinA,
+            yMinA: cfg.yMinA,
+            yMaxA: cfg.yMaxA,
+            domThrB: cfg.domThrB,
+            satMinB: cfg.satMinB,
+            yMinB: cfg.yMinB,
+            yMaxB: cfg.yMaxB,
             previewCanvas: canvas,
             preview: true,
             activeA: true,

--- a/game-engine.js
+++ b/game-engine.js
@@ -102,8 +102,8 @@ class BaseGame {
     this.container.className =
       'game' + (this.gameName ? ' ' + this.gameName : '');
 
-    if (win.Config?.get) {
-      const cfg = win.Config.get();
+    const cfg = win.cfg;
+    if (cfg) {
       Game.setTeams(cfg.teamA, cfg.teamB);
     }
   }


### PR DESCRIPTION
## Summary
- expose the cached configuration via getter properties on Config and window for direct `cfg` access
- update detection flows and auxiliary modules to retrieve the runtime config each time they run instead of caching it
- simplify setup to rely on the shared getter without rebinding globals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0126f2318832ca9050717f9cea9ee