### PR TITLE
Fix default config initialization

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -124,7 +124,7 @@
         cfg = window.cfg;
         for (const k of Object.keys(DEFAULTS)) {
           if (localStorage.getItem(k) === null) {
-            Config.save(k, cfg[k]);
+            Config.save(k, DEFAULTS[k]);
           }
         }
         window.Config = Config;


### PR DESCRIPTION
## Summary
- ensure default config values are saved when localStorage is empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0f1d1e31c832c8f94bedd1458069b