### PR TITLE
Fix Safari scoreboard stretching on iOS

### DIFF
--- a/style.css
+++ b/style.css
@@ -177,7 +177,7 @@ input {
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
   font-size: 24px;


### PR DESCRIPTION
## Summary
- prevent the scoreboard container from stretching to full width on Safari by switching it to `inline-flex`
- resolves the white bar that appeared at the top of games on iOS Safari 16

## Testing
- Manual verification in Chromium

------
https://chatgpt.com/codex/tasks/task_e_68d9519f7288832c8f98e00c094d3e9f