### PR TITLE
Fix ferris wheel hub alignment and hue animation

### DIFF
--- a/games/ferris.js
+++ b/games/ferris.js
@@ -56,7 +56,7 @@
   </g>
 
   <!-- hub -->
-  <text class="hub" font-size="90" x="50%" y="50%">🌟</text>
+  <text class="hub" font-size="90" x="50%" y="50%" text-anchor="middle" dominant-baseline="middle">🌟</text>
 
   <!-- 8 carts -->
   <g class="ferris-carts">

--- a/styles/ferris.css
+++ b/styles/ferris.css
@@ -86,7 +86,7 @@
 .game.ferris .hub
 {
   filter: hue-rotate(0deg) saturate(1.4);
-  animation: spinHue var(--duration) linear infinite;
+  animation: spinHue var(--period) linear infinite;
   will-change: filter;
   text-shadow: 0 0 6px rgba(255,255,255,.25), 0 0 22px rgba(255,255,200,.18);
   transform-origin: center;


### PR DESCRIPTION
## Summary
- center the Ferris wheel hub emoji by anchoring it to the SVG midpoint
- reuse the wheel rotation period for the hub hue animation so the effect runs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da33819be0832cbba1737b1deebfde