### PR TITLE
Initialize front ROI width and validate frontRect before GPU detection

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -136,6 +136,10 @@
       if (!frame) return { detected: false, hits: [] };
       const colorA = cfg.colorA;
       const colorB = cfg.colorB;
+      const frontRect = cfg.frontRectMM;
+      const validFrontRect = frontRect?.min && frontRect?.max &&
+        frontRect.max[0] > frontRect.min[0] &&
+        frontRect.max[1] > frontRect.min[1];
       const { a, b, w, h, resized } = await GPU.detect({
         key: 'front',
         source: frame,
@@ -151,7 +155,7 @@
         yMinB: cfg.yMinB,
         yMaxB: cfg.yMaxB,
         radiusPx: cfg.radiusPx,
-        rect: cfg.frontRectMM,  // may be null -> full-frame inside detect.js
+        rect: validFrontRect ? frontRect : null,  // may be null -> full-frame inside detect.js
         previewCanvas: preview ? $('#frontTex') : null,
         preview,
         activeA: aActive,

--- a/app/setup.js
+++ b/app/setup.js
@@ -304,6 +304,11 @@
 
         // Front ROI: fixed aspect, height-driven; gesture = drag only
         const frontAspect = cfg.frontResW / cfg.frontResH;
+        if (!cfg.frontRect || !(cfg.frontRect.w > 0) || !(cfg.frontRect.h > 0)) {
+          const width = Math.round(cfg.frontH * frontAspect);
+          cfg.frontRect = { x: 0, y: 0, w: width, h: cfg.frontH };
+          Config.save('frontRect', cfg.frontRect);
+        }
         let roi = { x: 0, y: 0, w: cfg.frontH * frontAspect, h: cfg.frontH };
         if (cfg.frontRect) {
           const x0 = cfg.frontRect.x, y0 = cfg.frontRect.y;


### PR DESCRIPTION
### Motivation
- The front ROI could be stored with missing or zero dimensions so UI height changes left the front rectangle with null/zero width. 
- Passing an invalid rect into the GPU detection path can produce incorrect behavior or runtime errors. 
- The front ROI is height-driven with a fixed aspect ratio and stored rectangles can drift from that constraint.

### Description
- In `app/setup.js` compute the front ROI width from the height and aspect (`width = Math.round(cfg.frontH * frontAspect)`) when `cfg.frontRect` is missing or has non-positive dimensions, then persist it with `Config.save('frontRect', ...)`.
- Keep the ROI width locked to `roi.h * frontAspect` and write the rounded `(x0,y0,x1,y1)` back into `cfg.frontRect` inside `commit()`.
- In `app/app.js` validate `cfg.frontRectMM` by checking `min`/`max` presence and that `max > min`, and pass `rect: validFrontRect ? frontRect : null` to `GPU.detect` so detection falls back to full-frame when the rect is invalid.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552fa64374832ca914ca3628ac99d9)