### PR TITLE
Revert front ROI rectangle handling changes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -136,10 +136,6 @@
       if (!frame) return { detected: false, hits: [] };
       const colorA = cfg.colorA;
       const colorB = cfg.colorB;
-      const frontRect = cfg.frontRectMM;
-      const validFrontRect = frontRect?.min && frontRect?.max &&
-        frontRect.max[0] > frontRect.min[0] &&
-        frontRect.max[1] > frontRect.min[1];
       const { a, b, w, h, resized } = await GPU.detect({
         key: 'front',
         source: frame,
@@ -155,7 +151,7 @@
         yMinB: cfg.yMinB,
         yMaxB: cfg.yMaxB,
         radiusPx: cfg.radiusPx,
-        rect: validFrontRect ? frontRect : null,  // may be null -> full-frame inside detect.js
+        rect: cfg.frontRectMM,  // may be null -> full-frame inside detect.js
         previewCanvas: preview ? $('#frontTex') : null,
         preview,
         activeA: aActive,

--- a/app/setup.js
+++ b/app/setup.js
@@ -304,11 +304,6 @@
 
         // Front ROI: fixed aspect, height-driven; gesture = drag only
         const frontAspect = cfg.frontResW / cfg.frontResH;
-        if (!cfg.frontRect || !(cfg.frontRect.w > 0) || !(cfg.frontRect.h > 0)) {
-          const width = Math.round(cfg.frontH * frontAspect);
-          cfg.frontRect = { x: 0, y: 0, w: width, h: cfg.frontH };
-          Config.save('frontRect', cfg.frontRect);
-        }
         let roi = { x: 0, y: 0, w: cfg.frontH * frontAspect, h: cfg.frontH };
         if (cfg.frontRect) {
           const x0 = cfg.frontRect.x, y0 = cfg.frontRect.y;


### PR DESCRIPTION
### Motivation
- Restore previous behavior for front-region-of-interest (ROI) handling after an upstream change that altered validation and initialization of the front ROI rectangle.
- Avoid the new validation/initialization logic that could change when `rect` is passed into detection or create implicit rectangle writes during setup.

### Description
- Reverted changes in `app/app.js` to remove the `validFrontRect` check and pass `rect: cfg.frontRectMM` directly to the detector instead of `validFrontRect ? frontRect : null`.
- Removed the automatic initialization block in `app/setup.js` that created and saved a default `cfg.frontRect` when stored values had non-positive width/height.
- Kept the ROI calculation and commit logic intact so downstream code continues to compute and save `cfg.frontRect` from `roi` during interactive setup.
- Changes affect `app/app.js` and `app/setup.js` and reduce the prior defensive handling introduced for the front ROI rectangle.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695537f9d8b4832c9978744aa7a09b88)