### PR TITLE
Add keyboard nudging and resize shortcuts for front ROI

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -362,6 +362,59 @@
         $('#frontOv')?.addEventListener('pointerup', lift);
         $('#frontOv')?.addEventListener('pointercancel', lift);
 
+        function isTypingTarget(el) {
+          if (!el) return false;
+          const tag = el.tagName;
+          return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+        }
+
+        // Keyboard nudges in front preview:
+        // WASD moves ROI by 1px; [ / ] resize ROI by 1px with fixed aspect ratio.
+        window.addEventListener('keydown', e => {
+          if (!window.Controller?.isPreview || isTypingTarget(e.target)) return;
+
+          let handled = true;
+          switch (e.key.toLowerCase()) {
+            case 'w':
+              roi.y -= 1;
+              break;
+            case 'a':
+              roi.x -= 1;
+              break;
+            case 's':
+              roi.y += 1;
+              break;
+            case 'd':
+              roi.x += 1;
+              break;
+            case '[': {
+              const nextH = u.clamp(Math.round(roi.h + 1), 10, frontResH);
+              const nextW = nextH * frontAspect();
+              roi.x -= (nextW - roi.w) / 2;
+              roi.y -= (nextH - roi.h) / 2;
+              roi.h = nextH;
+              break;
+            }
+            case ']': {
+              const nextH = u.clamp(Math.round(roi.h - 1), 10, frontResH);
+              const nextW = nextH * frontAspect();
+              roi.x -= (nextW - roi.w) / 2;
+              roi.y -= (nextH - roi.h) / 2;
+              roi.h = nextH;
+              break;
+            }
+            default:
+              handled = false;
+          }
+
+          if (!handled) return;
+          e.preventDefault();
+          cfg.frontH = Math.round(roi.h);
+          Config.save('frontH', cfg.frontH);
+          if ($('#frontHInp')) $('#frontHInp').value = cfg.frontH;
+          commit();
+        });
+
         if ($('#frontOv')) $('#frontOv').style.touchAction = 'none';
         if ($('#topHInp')) $('#topHInp').value = cfg.topH;
         if ($('#frontHInp')) $('#frontHInp').value = cfg.frontH;


### PR DESCRIPTION
### Motivation
- Provide keyboard controls to tweak the front-camera preview ROI without pointer dragging so users can fine-tune position and size quickly.
- Ensure resizing preserves the preview's fixed aspect ratio and keep keyboard moves disabled while typing in form fields.

### Description
- Added a keyboard handler in `app/setup.js` that listens for `keydown` when preview mode is active and the focus is not a typing target (`isTypingTarget`).
- Mapped `W/A/S/D` to move the ROI by 1px (up/left/down/right) and `[` / `]` to increase/decrease ROI height by 1px while re-centering and preserving the fixed aspect via `frontAspect()` before clamping.
- Persist updated height to `cfg.frontH`, save with `Config.save('frontH', ...)`, sync the `#frontHInp` input, and call `commit()` to apply/clamp the rectangle.
- Changes are in `app/setup.js` (keyboard guard, handler, and UI sync).

### Testing
- Ran `npx tsc --noEmit`; type-check failed in this environment due to missing Node type declarations in installed dependencies (errors referencing `node:http` and `NodeJS`), so full TypeScript validation was not possible.
- Launched a static server with `python3 -m http.server 4173` and manually exercised the UI, which served successfully.
- Captured a browser screenshot via a Playwright run against `http://127.0.0.1:4173/index.html` to validate visual integration, and the artifact was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ec749288832c948a81cb8eae9a8d)