### PR TITLE
Make launcher and config buttons keyboard-focusable

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -118,7 +118,6 @@
         update();
       });
     }
-
     function bind() {
       if (bound) return;
       bound = true;

--- a/game-engine.js
+++ b/game-engine.js
@@ -459,7 +459,8 @@ Game.register = (id, cls) => {
   if (launcher && cls.icon) {
     const btn = Object.assign(document.createElement('button'), {
       type: 'button',
-      textContent: cls.icon
+      textContent: cls.icon,
+      tabIndex: 0
     });
     Object.assign(btn.dataset, { game: id });
     launcher.prepend(btn);

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <pre id="state" style="position:absolute;top:0;left:0;margin:0;padding:4px;background:rgba(0,0,0,.5);color:#fff;font-family:monospace;font-size:12px;">Connecting…</pre>
   <div id="container">
     <div id="launcher">
-      <button type="button" data-config>⚙️</button>
+      <button type="button" data-config tabindex="0">⚙️</button>
     </div>
     <div id="gameScreen">
       <div id="scoreboard">


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility by ensuring launcher buttons and the config toggle can receive focus via the Tab key.
- Small cleanup to remove an extra blank line in the setup code.

### Description
- Add `tabindex="0"` to the config toggle button in `index.html` so it is keyboard-focusable.
- Add `tabIndex: 0` to programmatically created launcher buttons in `game-engine.js` to make them focusable by keyboard.
- Remove an extraneous blank line in `app/setup.js`.

### Testing
- No automated tests were added or modified for these UI accessibility changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ef15fd50832c9acd76a05abd19ec)