### PR TITLE
Add single view-cycle button, layout for combined view, and UI icon polish

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -248,9 +248,27 @@
 
         initNumberSpinners();
       $('#btnStart')?.addEventListener('click', () => Screen.snapTo(1));
-      $('#btnTop')?.addEventListener('click', () => $('#configScreen') && ($('#configScreen').className = 'onlyTop'));
-      $('#btnFront')?.addEventListener('click', () => $('#configScreen') && ($('#configScreen').className = 'onlyFront'));
-      $('#btnBoth')?.addEventListener('click', () => $('#configScreen') && ($('#configScreen').className = ''));
+
+      const VIEW_ICONS = {
+        onlyFront: '⛶',
+        onlyTop: '⇥',
+        both: '🀱'
+      };
+      const NEXT_VIEW_MODE = {
+        onlyFront: 'onlyTop',
+        onlyTop: 'both',
+        both: 'onlyFront'
+      };
+
+      let viewMode = 'onlyFront';
+      if ($('#configScreen')) $('#configScreen').className = viewMode;
+      if ($('#btnViewCycle')) $('#btnViewCycle').textContent = VIEW_ICONS[viewMode];
+
+      $('#btnViewCycle')?.addEventListener('click', () => {
+        viewMode = NEXT_VIEW_MODE[viewMode] || 'onlyFront';
+        if ($('#btnViewCycle')) $('#btnViewCycle').textContent = VIEW_ICONS[viewMode];
+        if ($('#configScreen') && $('#configScreen').className !== viewMode) $('#configScreen').className = viewMode;
+      });
 
       $('#start')?.addEventListener('click', () => {
         $('#start').disabled = true;

--- a/index.html
+++ b/index.html
@@ -39,10 +39,8 @@
       </div>
       <div id="cfg">
         <span>
-          <button id="btnTop">⇥</button>
-          <button id="btnFront">⛶</button>
-          <button id="btnBoth">🀱</button>
-          <button onclick="location.reload()">⟳</button>
+          <button id="btnViewCycle">⛶</button>
+          <button id="btnRefresh" onclick="location.reload()">⟳</button>
           <button id="btnStart">►</button>
         </span>
         <label for="frontZoom">🔍 <input id="frontZoom" type="number" step="0.01" min="1" style="width:3ch"></label>
@@ -66,10 +64,10 @@
           <option value="yellow">🟡</option>
         </select></label>
         <label for="radiusPx">⌀ <input id="radiusPx" type="number" style="width:6ch" step="5"    value="50"></label>
-        <label for="domA">      <input id="domA" type="number"     style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
-        <label for="satMinA">   <input id="satMinA" type="number"  style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
-        <label for="yMinA">     <input id="yMinA" type="number"    style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
-        <label for="yMaxA">     <input id="yMaxA" type="number"    style="width:6ch" step="0.05" value="1" min="0" max="1"></label>
+        <label for="domA">𝚫 <input id="domA" type="number"     style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
+        <label for="satMinA">🎨 <input id="satMinA" type="number"  style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
+        <label for="yMinA">🔅 <input id="yMinA" type="number"    style="width:6ch" step="0.05" value="0" min="0" max="1"></label>
+        <label for="yMaxA">🔆 <input id="yMaxA" type="number"    style="width:6ch" step="0.05" value="1" min="0" max="1"></label>
         <!-- <label for="topMinInp"> <input id="topMinInp" type="number"  style="width:6ch" min="0" max="1" step="0.005"></label>
         <label for="frontMinInp"><input id="frontMinInp" type="number" style="width:6ch" min="0" step="100"></label> -->
         <!-- <label for="domB">domB <input id="domB" type="number" step="0.01" style="width:5ch"></label>

--- a/style.css
+++ b/style.css
@@ -158,6 +158,7 @@ input {
 
 #configScreen.onlyFront { grid-template-areas: "cfg" "front"; }
 #configScreen.onlyTop   { grid-template-areas: "cfg"   "top"; }
+#configScreen.both      { grid-template-areas: "cfg cfg" "top front"; }
 
 #configScreen.onlyFront #topCam,
 #configScreen.onlyTop   #frontCam { display: none; }
@@ -170,6 +171,9 @@ input {
 
 #configScreen.onlyTop label:has(#topMode option[value="0"]:checked) + label[for=topUrl] { display: none; }
 #configScreen.onlyTop label:has(#topMode option[value="1"]:checked) + label[for=topUrl] { display: initial; }
+
+#cfg #btnRefresh { display: none; }
+#configScreen.onlyTop #cfg:has(#topMode option[value="1"]:checked) #btnRefresh { display: initial; }
 
 /* ---- Scoreboard ---- */
 #scoreboard {


### PR DESCRIPTION
### Motivation
- Simplify switching between top/front/both camera layouts by replacing three separate buttons with a single cycling control to reduce UI clutter.
- Provide a clear visual affordance for the current view using icons and ensure the layout supports a combined (`both`) view mode.
- Hide the refresh button unless it is relevant (when using MJPEG top mode) and make several small UI label/icon improvements.

### Description
- Replaced the three view buttons with a single `#btnViewCycle` and implemented `VIEW_ICONS` and `NEXT_VIEW_MODE` maps plus a `viewMode` state to cycle modes in `app/setup.js` and update `#configScreen.className` and the button icon accordingly.
- Removed the old `#btnTop`, `#btnFront`, and `#btnBoth` handlers and added initial assignment of the `viewMode` to the `#configScreen` element in `app/setup.js`.
- Updated `index.html` to use a single `#btnViewCycle` plus a `#btnRefresh` and replaced several plain labels with emoji icons to improve clarity.
- Expanded `style.css` with a `#configScreen.both` layout (`grid-template-areas`), added CSS to hide `#btnRefresh` by default and show it conditionally when top mode is MJPEG using `:has()`, and kept existing rules for single-view modes.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3042c69c832ca16c08f25ee443cf)