### PR TITLE
Tighten setup input style consistency

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,8 +86,15 @@ body {
   flex-wrap: wrap;
   justify-content: left;
   align-items: flex-start;
-  gap: .5rem;
-  padding: 1rem;
+  gap: .3rem;
+  padding: .5rem;
+}
+
+#cfg > span,
+#cfg label {
+  display: inline-flex;
+  align-items: center;
+  gap: .2rem;
 }
 
 /* ────────── Cameras ────────── */
@@ -146,8 +153,15 @@ input {
   line-height: 1;
   min-height: 2rem;
   min-width: 2rem;
-  padding: .5rem 0;
+  padding: .45rem .2rem;
   border-radius: .5rem;
+}
+
+#cfg button,
+#cfg select,
+#cfg input {
+  min-width: 0;
+  padding-inline: .15rem;
 }
 
 /* ────────── Mode switches ────────── */


### PR DESCRIPTION
### Motivation
- Make the setup/config toolbar denser and more visually consistent by reducing excessive horizontal padding and gaps around inputs and control groups.
- Reduce min-width pressure from global control rules so inputs and selects can shrink to fit the tighter layout without affecting tap-target height.

### Description
- Reduced the config bar outer padding and intra-control gap by changing `#cfg` padding from `1rem` to `.5rem` and `gap` from `.5rem` to `.3rem` in `style.css`.
- Standardized inline alignment for control groups by making `#cfg > span` and `#cfg label` `display: inline-flex` with `align-items: center` and a small `gap: .2rem`.
- Tightened global control horizontal padding by changing the generic `button, select, input` padding to `padding: .45rem .2rem` and added `#cfg button, #cfg select, #cfg input { min-width: 0; padding-inline: .15rem; }` to allow controls inside the config bar to be narrower.

### Testing
- Ran `npx tsc --noEmit` which failed in this environment due to missing Node type declarations from installed Netlify packages (environment/dependency issue), not due to the CSS change.
- Served the app with `python3 -m http.server 4173` and verified the UI loads successfully.
- Captured a visual verification screenshot via Playwright against `http://127.0.0.1:4173/index.html`, which shows the updated, tighter setup controls successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad2c4392a8832ca7480abf2cba33e7)