### PR TITLE
Add toggle to hide numeric inputs in config bar and adjust layout spacing

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -264,6 +264,11 @@
       if ($('#configScreen')) $('#configScreen').className = viewMode;
       if ($('#btnViewCycle')) $('#btnViewCycle').textContent = VIEW_ICONS[viewMode];
 
+
+      $('#btnNumberInputs')?.addEventListener('click', () => {
+        $('#cfg')?.classList.toggle('hide-number-inputs');
+      });
+
       $('#btnViewCycle')?.addEventListener('click', () => {
         viewMode = NEXT_VIEW_MODE[viewMode] || 'onlyFront';
         if ($('#btnViewCycle')) $('#btnViewCycle').textContent = VIEW_ICONS[viewMode];

--- a/index.html
+++ b/index.html
@@ -37,9 +37,10 @@
         <canvas id="frontTex"></canvas>
         <canvas id="frontOv" class="overlay"></canvas>
       </div>
-      <div id="cfg">
+      <div id="cfg" class="hide-number-inputs">
         <span>
           <button id="btnViewCycle">⛶</button>
+          <button id="btnNumberInputs" type="button">🎚️</button>
           <button id="btnRefresh" onclick="location.reload()">⟳</button>
           <button id="btnStart">►</button>
         </span>

--- a/style.css
+++ b/style.css
@@ -86,8 +86,8 @@ body {
   flex-wrap: wrap;
   justify-content: left;
   align-items: flex-start;
-  gap: .3rem;
-  padding: .5rem;
+  gap: .5rem;
+  padding: 1rem;
 }
 
 #cfg > span,
@@ -153,15 +153,8 @@ input {
   line-height: 1;
   min-height: 2rem;
   min-width: 2rem;
-  padding: .45rem .2rem;
+  padding: .5rem 0;
   border-radius: .5rem;
-}
-
-#cfg button,
-#cfg select,
-#cfg input {
-  min-width: 0;
-  padding-inline: .15rem;
 }
 
 /* ────────── Mode switches ────────── */
@@ -187,6 +180,8 @@ input {
 #configScreen.onlyTop label:has(#topMode option[value="1"]:checked) + label[for=topUrl] { display: initial; }
 
 #cfg #btnRefresh { display: none; }
+
+#cfg.hide-number-inputs .num-spinner { display: none; }
 #configScreen.onlyTop #cfg:has(#topMode option[value="1"]:checked) #btnRefresh { display: initial; }
 
 /* ---- Scoreboard ---- */


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the configuration bar by allowing numeric spinner controls to be hidden behind a toggle. 
- Improve spacing and padding of the config bar to make controls more touch-friendly. 

### Description
- Add a new button `#btnNumberInputs` to the config bar and wire it up in `app/setup.js` to toggle the `hide-number-inputs` class on `#cfg`. 
- Set the default state by adding `class="hide-number-inputs"` to the `#cfg` element in `index.html` so numeric spinners are hidden by default. 
- Add CSS rule `#cfg.hide-number-inputs .num-spinner { display: none; }` and adjust other layout metrics (`#cfg` gap and padding, general button padding) in `style.css` to improve spacing. 
- Minor HTML/CSS cleanups to the config bar and control styles to align with the new toggle behavior. 

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad588d0ee4832cbf0607b3e2a47818)