### PR TITLE
Hide number input labels when toggle off and move 🎚️ after play

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
       <div id="cfg" class="hide-number-inputs">
         <span>
           <button id="btnViewCycle">⛶</button>
-          <button id="btnNumberInputs">🎚️</button>
           <button id="btnRefresh">⟳</button>
           <button id="btnStart">►</button>
+          <button id="btnNumberInputs">🎚️</button>
         </span>
         <label for="frontZoom">🔍 <input id="frontZoom" type="number" step="0.01" min="1" data-spinner></label>
         <label for="topHInp">↕️ <input id="topHInp" type="number" min="10" step="1"></label>

--- a/style.css
+++ b/style.css
@@ -201,7 +201,11 @@ input {
 
 #cfg #btnRefresh { display: none; }
 
-#cfg.hide-number-inputs .num-spinner { display: none; }
+#cfg.hide-number-inputs .num-spinner,
+#cfg.hide-number-inputs label:has(input[type="number"]),
+#cfg.hide-number-inputs label[for="frontZoom"] {
+  display: none;
+}
 #configScreen.onlyTop #cfg:has(#topMode option[value="1"]:checked) #btnRefresh { display: initial; }
 
 /* ---- Scoreboard ---- */


### PR DESCRIPTION
### Motivation
- Make the configuration UI fully hide numeric controls when the number-inputs toggle is off, including their labels and the zoom control, and place the 🎚️ toggle after the play button for a more logical control order.

### Description
- Reordered the buttons in `index.html` so `#btnNumberInputs` appears after the play button (`#btnStart`).
- Extended the `#cfg.hide-number-inputs` CSS rule in `style.css` to also hide `label:has(input[type="number"])` and the `label[for="frontZoom"]` so labels and the zoom control are hidden when the toggle is off.

### Testing
- Started a local server with `python3 -m http.server 4173` and validated the hidden-input state by running a Playwright script that loaded `http://127.0.0.1:4173/index.html` and produced a screenshot, which succeeded.  
- Verified changes with `git diff` and committed the updates, both operations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad99e0ab50832ca56cf1462890ee6e)