### PR TITLE
Remove bottom padding from setup inputs and normalize frontZoom input

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           <button id="btnStart">►</button>
           <button id="btnNumberInputs">🎚️</button>
         </span>
-        <label for="frontZoom">🔍 <input id="frontZoom" type="number" step="0.01" min="1" data-spinner></label>
+        <label for="frontZoom">🔍 <input id="frontZoom" type="number" class="input-w-6ch" step="0.05" min="1"></label>
         <label for="topHInp">↕️ <input id="topHInp" type="number" min="10" step="1"></label>
         <label for="frontHInp">↕️ <input id="frontHInp" type="number" min="10" step="1"></label>
         <label for="topMode">📡 <select id="topMode">

--- a/style.css
+++ b/style.css
@@ -107,7 +107,7 @@ body {
   justify-content: left;
   align-items: flex-start;
   gap: .5rem;
-  padding: 1rem;
+  padding: 1rem 1rem 0;
 }
 
 #cfg > span,


### PR DESCRIPTION
### Motivation
- Make the setup/config row flush at the bottom and make the front zoom control match the other numeric inputs for consistent sizing and spinner handling.

### Description
- Adjusted `#cfg` padding from `1rem` to `1rem 1rem 0` in `style.css` and changed the `frontZoom` input in `index.html` to use `class="input-w-6ch"`, `step="0.05"` and removed the manual `data-spinner` attribute so it is initialized uniformly by the setup script.

### Testing
- Started a local server with `python -m http.server 4173` and used Playwright to open `http://127.0.0.1:4173/index.html` and capture a screenshot of the config panel, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada3be4e3c832c96cff982eadbec4f)