### PR TITLE
Reorder config controls around play button

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,16 +42,7 @@
           <button id="btnViewCycle">⛶</button>
           <button id="btnRefresh">⟳</button>
           <button id="btnStart">►</button>
-          <button id="btnNumberInputs">🎚️</button>
         </span>
-        <label for="frontZoom">🔍 <input id="frontZoom" type="number" class="input-w-6ch" step="0.05" min="1"></label>
-        <label for="topHInp">↕️ <input id="topHInp" type="number" min="10" step="1"></label>
-        <label for="frontHInp">↕️ <input id="frontHInp" type="number" min="10" step="1"></label>
-        <label for="topMode">📡 <select id="topMode">
-          <option value="0">WebRTC</option>
-          <option value="1">MJPEG</option>
-        </select></label>
-        <label for="topUrl">🔗 <input id="topUrl" size="28"><span id="urlWarn"></span></label>
         <label for="teamA">🅰️ <select id="teamA">
           <option value="red">🔴</option>
           <option value="green">🟢</option>
@@ -64,6 +55,15 @@
           <option value="blue">🔵</option>
           <option value="yellow">🟡</option>
         </select></label>
+        <button id="btnNumberInputs">🎚️</button>
+        <label for="frontZoom">🔍 <input id="frontZoom" type="number" class="input-w-6ch" step="0.05" min="1"></label>
+        <label for="topHInp">↕️ <input id="topHInp" type="number" min="10" step="1"></label>
+        <label for="frontHInp">↕️ <input id="frontHInp" type="number" min="10" step="1"></label>
+        <label for="topMode">📡 <select id="topMode">
+          <option value="0">WebRTC</option>
+          <option value="1">MJPEG</option>
+        </select></label>
+        <label for="topUrl">🔗 <input id="topUrl" size="28"><span id="urlWarn"></span></label>
         <label for="radiusPx">⌀ <input id="radiusPx" type="number" class="input-w-6ch" step="5" value="50"></label>
         <label for="domA">𝚫 <input id="domA" type="number" class="input-w-6ch" step="0.05" value="0" min="0" max="1"></label>
         <label for="satMinA">🎨 <input id="satMinA" type="number" class="input-w-6ch" step="0.05" value="0" min="0" max="1"></label>


### PR DESCRIPTION
### Motivation
- Improve the configuration panel layout so team selectors appear immediately after the play button and all numeric/advanced inputs that are toggled by the `🎚️` button are positioned after that toggle for clearer UX.

### Description
- Moved the `🅰️` (`#teamA`) and `🅱️` (`#teamB`) selector labels to immediately follow the `#btnStart` play button in `index.html`.
- Moved the `#btnNumberInputs` toggle so it precedes the numeric/advanced controls and relocated the related labels (`#frontZoom`, `#topHInp`, `#frontHInp`, `#topMode`, `#topUrl`) to appear after the toggle.
- Preserved all original element IDs and markup semantics so behavior and styling remain unchanged apart from control order.

### Testing
- Ran `git diff --check` which reported no problems.
- Served the app locally with `python -m http.server 4173` and confirmed the page responds with HTTP 200 via `curl -I`.
- Captured a Playwright (Firefox) screenshot of the config panel for visual verification and confirmed the updated order (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada63c6764832c9bf63785eb5ab2ea)