### PR TITLE
Overlay setup controls on config canvas

### DIFF
--- a/style.css
+++ b/style.css
@@ -88,12 +88,12 @@ body {
   font-size: 1rem;
   line-height: 1;
   display: grid;
+  position: relative;
   background: var(--clr-green);
   place-content: center;
-  gap: 1rem;                         /* consistent spacing */
+  gap: 0;
   grid:
-    "cfg  cfg"   auto               /* second row: full-width bar    */
-    "top  front" 1fr                /* first row: two equal tracks   */
+    "top  front" 1fr
     / 1fr 1fr;         
 }
 
@@ -108,13 +108,17 @@ body {
 
 /* Config-bar */
 #cfg {
-  grid-area: cfg;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
   display: flex;
   flex-wrap: wrap;
   justify-content: left;
   align-items: flex-start;
   gap: .5rem;
-  padding: 1rem 1rem 0;
+  padding: 1rem;
 }
 
 #cfg > span,
@@ -202,9 +206,9 @@ input {
   grid-template-columns: 1fr;
 }
 
-#configScreen.onlyFront { grid-template-areas: "cfg" "front"; }
-#configScreen.onlyTop   { grid-template-areas: "cfg"   "top"; }
-#configScreen.both      { grid-template-areas: "cfg cfg" "top front"; }
+#configScreen.onlyFront { grid-template-areas: "front"; }
+#configScreen.onlyTop   { grid-template-areas: "top"; }
+#configScreen.both      { grid-template-areas: "top front"; }
 
 #configScreen.onlyFront #topCam,
 #configScreen.onlyTop   #frontCam { display: none; }


### PR DESCRIPTION
### Motivation
- The setup controls currently occupy a dedicated grid row which pushes the camera canvases down; the change aims to overlay the controls on top of the camera/video area so the canvases fill the screen.
- Keep the controls accessible while preventing layout shifts when entering setup/config modes.

### Description
- Changed `#configScreen` to `position: relative`, removed the extra controls grid row by simplifying the `grid` to only camera areas, and set `gap: 0` so camera areas fill available height.
- Converted the controls bar from a flow item to an overlay by replacing `#cfg { grid-area: cfg; }` with `#cfg { position: absolute; top: 0; left: 0; right: 0; z-index: 10; padding: 1rem; }` so it sits above canvas/video layers.
- Adjusted mode-specific templates so `#configScreen.onlyFront`, `#configScreen.onlyTop`, and `#configScreen.both` use only camera areas (`"front"`, `"top"`, `"top front"`) to avoid reserving layout height for the controls.
- Only `style.css` was modified.

### Testing
- Verified the diff with `git diff -- style.css` which showed only `style.css` changes and then committed the change successfully.
- Launched a local server with `python -m http.server 4173` and confirmed static assets were served without errors.
- Ran a Playwright script that opened `http://localhost:4173`, clicked the settings button (`button[data-config]`), and captured `artifacts/config-overlay.png` to confirm the controls render as an overlay (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19e8577c8832c8b9cb7409fbda875)