### PR TITLE
Add additional front preview guide lines at edge percentages

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -62,15 +62,16 @@
 
     const centerX = Math.round(width * 0.5) + 0.5;
     const centerY = Math.round(height * 0.5) + 0.5;
-    const quarterXs = [0.25, 0.75].map(ratio => Math.round(width * ratio) + 0.5);
-    const quarterYs = [0.25, 0.75].map(ratio => Math.round(height * ratio) + 0.5);
+    const guideRatios = [0.05, 0.10, 0.15, 0.20, 0.25, 0.75, 0.80, 0.85, 0.90, 0.95];
+    const guideXs = guideRatios.map(ratio => Math.round(width * ratio) + 0.5);
+    const guideYs = guideRatios.map(ratio => Math.round(height * ratio) + 0.5);
 
     ctxFrontGuides2d.lineWidth = 1;
 
-    for (const x of quarterXs) {
+    for (const x of guideXs) {
       strokeGuideLine(ctxFrontGuides2d, x, 0, x, height, 'rgba(220, 245, 255, 0.25)');
     }
-    for (const y of quarterYs) {
+    for (const y of guideYs) {
       strokeGuideLine(ctxFrontGuides2d, 0, y, width, y, 'rgba(220, 245, 255, 0.25)');
     }
 


### PR DESCRIPTION
### Motivation
- Improve the front preview overlay by adding extra horizontal and vertical guide lines near the edges to help with alignment and positioning at common percentages.

### Description
- Update `drawFrontGuides` in `app/app.js` to compute guide positions from `guideRatios = [0.05, 0.10, 0.15, 0.20, 0.25, 0.75, 0.80, 0.85, 0.90, 0.95]`, map those into `guideXs` and `guideYs`, and draw the additional vertical and horizontal guide lines while preserving the existing center lines.

### Testing
- Ran `node --check app/app.js` which succeeded.
- Served the app with `python3 -m http.server 4173` and used a Playwright screenshot script against `http://127.0.0.1:4173/index.html` for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c04e25d4832c81c00d2321aef98c)